### PR TITLE
Workflow for ADM Notification

### DIFF
--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -59,8 +59,11 @@ exports.renderIndex = function (req, res) {
       linkedIn                : req.user.linkedIn,
       isPublicProfile         : req.user.isPublicProfile,
       isAutoAdd               : req.user.isAutoAdd,
-      capabilityDetails : req.user.capabilityDetails,
-      capabilitySkills : req.user.capabilitySkills
+      capabilityDetails       : req.user.capabilityDetails,
+      capabilitySkills        : req.user.capabilitySkills,
+      preferredAdmEmail       : req.user.preferredAdmEmail,
+      preferredBfsEmail       : req.user.preferredBfsEmail,
+      preferredDfsEmail       : req.user.preferredDfsEmail
     };
   }
   var features = config.features.split ('-');

--- a/modules/core/server/email_templates/opportunity-publish-approval-body.md
+++ b/modules/core/server/email_templates/opportunity-publish-approval-body.md
@@ -1,0 +1,34 @@
+{{#markdown this}}
+![BC Dev Exchange](https://bcdevexchange.org/modules/core/client/img/logo/new-logo-220px.png)
+
+A new *Code With Us* opportunity is pending and awaiting your approval.  Please review the information below, and choose *Agree* or *Disagree* to approve or deny publication of the opportunity.
+
+### {{ data.opportunityId }}
+
+- Associated RFP Control: **{{ data.rfp }}**
+- Posting Date: **{{ data.postingDate }}**
+- Value: **${{ data.value }}**
+- Required Skills: **{{ data.requiredSkills }}**
+- Closing Date: **{{ data.closingDate }}**
+
+---
+
+{{/markdown}}
+
+<style>
+    a {
+        font: bold 14px Arial;
+        text-decoration: none;
+        background-color: #EEEEEE;
+        color: #333333;
+        padding: 2px 6px 2px 6px;
+        border-top: 1px solid #CCCCCC;
+        border-right: 1px solid #333333;
+        border-bottom: 1px solid #333333;
+        border-left: 1px solid #CCCCCC;
+    }
+</style>
+<div width=100% align=center>
+    <a href="https://bcdevexchange.org/path/to/opp/approval">Agree</a>&nbsp;&nbsp;
+    <a href="https://bcdevexchange.org/path/to/opp/deny">Disagree</a>
+</div>

--- a/modules/core/server/email_templates/opportunity-publish-approval-subject.md
+++ b/modules/core/server/email_templates/opportunity-publish-approval-subject.md
@@ -1,0 +1,1 @@
+New Code With Us opportunity awaiting your approval

--- a/modules/opportunities/client/config/opportunities.client.routes.js
+++ b/modules/opportunities/client/config/opportunities.client.routes.js
@@ -218,39 +218,28 @@
 		})
 		// -------------------------------------------------------------------------
 		//
-		// AS - submit an opportunity
+		// AS - submit an opportunity for publication
 		//
 		// -------------------------------------------------------------------------
 		.state('opportunityadmin.submitcwu', {
 			url: '/:opportunityId/submitcwu',
-			params: {
-				programId: null,
-				projectId: null
-			},
 			templateUrl: '/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html',
-			controller: 'OpportunityEditController',
+			controller: 'OpportunitySubmissionController',
 			controllerAs: 'vm',
 			resolve: {
 				opportunity: function ($stateParams, OpportunitiesService) {
 					return OpportunitiesService.get({
 						opportunityId: $stateParams.opportunityId
 					}).$promise;
-				},
-				programs: function (ProgramsService) {
-					return ProgramsService.myadmin().$promise;
-				},
-				projects: function(ProjectsService) {
-					return ProjectsService.myadmin().$promise;
-				},
-				editing: function() { return true; }
+				}
 			},
 			data: {
 				roles: ['admin', 'gov'],
 				pageTitle: 'Opportunity: {{ opportunity.name }}'
 			},
 			ncyBreadcrumb: {
-				label: 'Edit Opportunity',
-				parent: 'opportunities.editcwu'
+				label: 'Opportunity',
+				parent: 'opportunities.list'
 			}
 		})
 		// -------------------------------------------------------------------------

--- a/modules/opportunities/client/config/opportunities.client.routes.js
+++ b/modules/opportunities/client/config/opportunities.client.routes.js
@@ -218,6 +218,43 @@
 		})
 		// -------------------------------------------------------------------------
 		//
+		// AS - submit an opportunity
+		//
+		// -------------------------------------------------------------------------
+		.state('opportunityadmin.submitcwu', {
+			url: '/:opportunityId/submitcwu',
+			params: {
+				programId: null,
+				projectId: null
+			},
+			templateUrl: '/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html',
+			controller: 'OpportunityEditController',
+			controllerAs: 'vm',
+			resolve: {
+				opportunity: function ($stateParams, OpportunitiesService) {
+					return OpportunitiesService.get({
+						opportunityId: $stateParams.opportunityId
+					}).$promise;
+				},
+				programs: function (ProgramsService) {
+					return ProgramsService.myadmin().$promise;
+				},
+				projects: function(ProjectsService) {
+					return ProjectsService.myadmin().$promise;
+				},
+				editing: function() { return true; }
+			},
+			data: {
+				roles: ['admin', 'gov'],
+				pageTitle: 'Opportunity: {{ opportunity.name }}'
+			},
+			ncyBreadcrumb: {
+				label: 'Edit Opportunity',
+				parent: 'opportunities.editcwu'
+			}
+		})
+		// -------------------------------------------------------------------------
+		//
 		// edit a opportunity
 		//
 		// -------------------------------------------------------------------------

--- a/modules/opportunities/client/controllers/opportunities.client.controller.js
+++ b/modules/opportunities/client/controllers/opportunities.client.controller.js
@@ -714,7 +714,6 @@
 			//
 			var savemeSeymour = true;
 			var promise = Promise.resolve ();
-			
 			// AS - Since workflow for publishing is changing to be handled by ADM approval workflow, comment out the following check
 			// This would now likely be handled by the workflow for ADM Authorization
 			//
@@ -753,7 +752,6 @@
 				else {
 					$state.go('opportunities.viewcwu', {opportunityId:opportunity.code});
 				}
-				
 			})
 			//
 			// fail, notify and stay put
@@ -802,12 +800,11 @@
 					{
 						useremail: vm.user.preferredAdmEmail + ';' + vm.user.preferredDfsEmail + ';' + vm.user.preferredBfsEmail,
 						opportunityId: vm.opportunity.code,
-						rfp: vm.opportunity.proposal != null ? vm.opportunity.proposal : "Not specified",
+						rfp: vm.opportunity.proposal != null ? vm.opportunity.proposal : 'Not specified',
 						postingDate: new Date(vm.opportunity.start).toDateString(),
 						value: vm.opportunity.earn,
-						requiredSkills: vm.opportunity.skills.join(", "),
+						requiredSkills: vm.opportunity.skills.join(', '),
 						closingDate: new Date(vm.opportunity.deadline).toDateString()
-					
 					}
 				).$promise;
 
@@ -822,7 +819,7 @@
 					function(response) {
 						Notification.error({
 							title: '<i class=\'glyphicon glyphicon-remove\'></i>Approval request failed to send.',
-							message: "Please confirm you have entered valid email addresses."
+							message: 'Please confirm you have entered valid email addresses.'
 						});
 					}
 				);

--- a/modules/opportunities/client/controllers/opportunities.client.controller.js
+++ b/modules/opportunities/client/controllers/opportunities.client.controller.js
@@ -744,13 +744,13 @@
 			//
 			.then(function () {
 				vm.opportunityForm.$setPristine();
+				Notification.success ({
+					message : '<i class="glyphicon glyphicon-ok"></i> opportunity saved successfully!'
+				});
 				if (isSubmitting) {
 					$state.go('opportunityadmin.submitcwu', {opportunityId:opportunity.code});
 				}
 				else {
-					Notification.success ({
-						message : '<i class="glyphicon glyphicon-ok"></i> opportunity saved successfully!'
-					});
 					$state.go('opportunities.viewcwu', {opportunityId:opportunity.code});
 				}
 				
@@ -800,7 +800,7 @@
 				// Send the notification via the OpportunitiesService
 				var notificationPromise = OpportunitiesService.submitOpportunity(
 					{
-						useremail: vm.user.preferredAdmEmail,
+						useremail: vm.user.preferredAdmEmail + ';' + vm.user.preferredDfsEmail + ';' + vm.user.preferredBfsEmail,
 						opportunityId: vm.opportunity.code,
 						rfp: vm.opportunity.proposal != null ? vm.opportunity.proposal : "Not specified",
 						postingDate: new Date(vm.opportunity.start).toDateString(),
@@ -815,13 +815,13 @@
 				Promise.all([updatePromise, notificationPromise]).then(
 					function() {
 						Notification.success({
-							message: "Approval request has been submitted."
+							message: '<i class="glyphicon glyphicon-ok"></i>Approval request has been submitted.'
 						});
 						$state.go('opportunities.viewcwu', {opportunityId:opportunity.code});
 					},
 					function(response) {
 						Notification.error({
-							title: "Approval request failed to send.",
+							title: '<i class=\'glyphicon glyphicon-remove\'></i>Approval request failed to send.',
 							message: "Please confirm you have entered valid email addresses."
 						});
 					}

--- a/modules/opportunities/client/services/opportunities.client.service.js
+++ b/modules/opportunities/client/services/opportunities.client.service.js
@@ -93,6 +93,10 @@
 			denyMember: {
 				method: 'GET',
 				url : '/api/opportunities/requests/deny/:opportunityId/:userId'
+			},
+			submitOpportunity: {
+				method: 'POST',
+				url : '/api/opportunities/submit/for/approval'
 			}
 		});
 		angular.extend (Opportunity.prototype, {

--- a/modules/opportunities/client/views/cwu-opportunity-edit.html
+++ b/modules/opportunities/client/views/cwu-opportunity-edit.html
@@ -12,7 +12,7 @@
 
 <section class="edit-form-background" role="main">
 
-	<form id="opportunityForm" warn-on-exit name="vm.opportunityForm" class="form" ng-submit="vm.save(vm.opportunityForm.$valid)" novalidate>
+	<form id="opportunityForm" warn-on-exit name="vm.opportunityForm" class="form" novalidate>
 
 
 		<div class="container edit-form">
@@ -59,7 +59,8 @@
 			<div class="edit-form-footer">
 				<div class="row">
 					<div class="col-xs-12">
-						<button type="submit" href="javascript:void(0);" class="btn btn-primary pull-right"><i class="fa fa-save"></i> Save Changes</button>
+						<button ng-click="vm.save(vm.opportunityForm.$valid, true)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Submit this opportunity for approval"><i class="fa fa-save"></i> Submit</button>
+						<button ng-click="vm.save(vm.opportunityForm.$valid, false)" href="javascript:void(0);" class="btn btn-primary pull-right" title="Save a draft of this opportunity"><i class="fa fa-save"></i> Save Changes</button>
 						<a href="javascript:void(0);" ng-if="vm.editing" class="btn btn-text-only" ng-click="vm.remove()" title="Remove"><i class="fa fa-trash"></i> Delete this Opportunity</a>
 					</div>
 				</div>

--- a/modules/opportunities/client/views/cwu-opportunity-edit.html
+++ b/modules/opportunities/client/views/cwu-opportunity-edit.html
@@ -59,7 +59,7 @@
 			<div class="edit-form-footer">
 				<div class="row">
 					<div class="col-xs-12">
-						<button ng-click="vm.save(vm.opportunityForm.$valid, true)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Submit this opportunity for approval"><i class="fa fa-save"></i> Submit</button>
+						<button ng-click="vm.save(vm.opportunityForm.$valid, true)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Submit this opportunity for approval"><i class="fa fa-bullhorn"></i> Submit</button>
 						<button ng-click="vm.save(vm.opportunityForm.$valid, false)" href="javascript:void(0);" class="btn btn-primary pull-right" title="Save a draft of this opportunity"><i class="fa fa-save"></i> Save Changes</button>
 						<a href="javascript:void(0);" ng-if="vm.editing" class="btn btn-text-only" ng-click="vm.remove()" title="Remove"><i class="fa fa-trash"></i> Delete this Opportunity</a>
 					</div>

--- a/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
+++ b/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
@@ -23,10 +23,11 @@
                     </span>
                     {{vm.opportunity.name}}
                 </span>
-				<a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
-				<a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a>
-			</div>
 
+				<a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
+                <a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a>
+			</div>
+            <p>Please provide/confirm the required email addresses below and press <b>Submit</b> to complete the publication request.</b></p>
              <fieldset>
                 <form-input
                     type="email"
@@ -77,7 +78,7 @@
 			<div class="edit-form-footer">
 				<div class="row">
 					<div class="col-xs-12">
-						<button ng-click="vm.submitForApproval(vm.submitForApprovalForm.$valid)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Send approval request"><i class="fa fa-save"></i> Submit</button>
+						<button ng-click="vm.submitForApproval(vm.submitForApprovalForm.$valid)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Send approval request"><i class="fa fa-bullhorn"></i> Submit</button>
 					</div>
 				</div>
 			</div>

--- a/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
+++ b/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
@@ -1,0 +1,90 @@
+<!-- Persistent banner for Opportunity Creators -->
+<div class="banner banner-important" >
+	<div class="container">
+		<div class="row">
+			<div class="col-xs-12">
+				<p>By posting an opportunity on the BCDevExchange, you are agreeing to follow the <a href="/api/proposals/download/terms/cwu1" target="_blank"><i class="fa fa-download"></i> terms</a> of our lightweight procurement model, Code With Us. Make sure you're familiar with the process and understand your responsibilities for managing an opportunity. <a href="https://github.com/BCDevExchange/code-with-us/wiki/2.-For-Public-Sector-Employees:-How-to-Manage-a-Code-With-Us-Opportunity" target="_blank">Read the guide</a></p>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+<section class="edit-form-background" role="main">
+
+	<form id="submitForApprovalForm" warn-on-exit name="vm.submitForApprovalForm" class="form" novalidate>
+
+		<div class="container edit-form">
+
+			<div class="edit-form-header">
+                <span>
+                    <span class="light small">
+                        SUBMITTING:
+                    </span>
+                    {{vm.opportunity.name}}
+                </span>
+				<!-- <a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
+				<a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a> -->
+			</div>
+
+             <fieldset>
+                <form-input
+                    class="col-sm-12"
+                    ng-model="vm.user.preferredAdm"
+                    x-form="vm.submitForApprovalForm"
+                    x-options='{
+                        "title":"Assistant Deputy Minister Email",
+                        "help":"Enter the email of an ADM where the approval request will be sent.",
+                        "id":"adm",
+                        "name":"adm",
+                        "placeholder":"firstname.lastname@gov.bc.ca"
+                    }'>
+                 </form-input>
+
+                 <form-input
+                    class="col-sm-12"
+                    ng-model="vm.user.preferredDfs"
+                    x-form="vm.submitForApprovalForm"
+                    x-options='{
+                        "title":"Divisional Financial Staff Email",
+                        "help":"Enter the email of a DFS where the approval request will be sent.",
+                        "id":"dfs",
+                        "name":"dfs",
+                        "placeholder":"firstname.lastname@gov.bc.ca"
+                    }'>
+                 </form-input>
+
+                 <form-input
+                    class="col-sm-12"
+                    ng-model="vm.user.preferredBfs"
+                    x-form="vm.submitForApprovalForm"
+                    x-options='{
+                        "title":"Branch Financial Staff Email",
+                        "help":"Enter the email of a BFS where the approval request will be sent.",
+                        "id":"bfs",
+                        "name":"bfs",
+                        "placeholder":"firstname.lastname@gov.bc.ca"
+                    }'>
+                 </form-input>
+
+                <form-display
+                    class="col-sm-12"
+                    x-options='{
+                        "title":"Email Body",
+                        "name":"emailbody",
+                        "help":"Confirm/edit the email body below before submitting"
+                    }'>
+                    <textarea class="form-control" cols="30" rows="3"></textarea>
+                </form-display>
+	        </fieldset> 
+
+			<div class="edit-form-footer">
+				<div class="row">
+					<div class="col-xs-12">
+						<button ng-click="" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Send approval request"><i class="fa fa-save"></i> Submit</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</form>
+</section>

--- a/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
+++ b/modules/opportunities/client/views/cwu-opportunity-submit-for-approval.html
@@ -12,7 +12,7 @@
 
 <section class="edit-form-background" role="main">
 
-	<form id="submitForApprovalForm" warn-on-exit name="vm.submitForApprovalForm" class="form" novalidate>
+	<form id="submitForApprovalForm" name="vm.submitForApprovalForm" class="form" novalidate>
 
 		<div class="container edit-form">
 
@@ -23,14 +23,15 @@
                     </span>
                     {{vm.opportunity.name}}
                 </span>
-				<!-- <a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
-				<a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a> -->
+				<a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
+				<a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a>
 			</div>
 
              <fieldset>
                 <form-input
+                    type="email"
                     class="col-sm-12"
-                    ng-model="vm.user.preferredAdm"
+                    ng-model="vm.user.preferredAdmEmail"
                     x-form="vm.submitForApprovalForm"
                     x-options='{
                         "title":"Assistant Deputy Minister Email",
@@ -38,12 +39,14 @@
                         "id":"adm",
                         "name":"adm",
                         "placeholder":"firstname.lastname@gov.bc.ca"
-                    }'>
+                    }' 
+                    required>
                  </form-input>
 
                  <form-input
+                    type="email"
                     class="col-sm-12"
-                    ng-model="vm.user.preferredDfs"
+                    ng-model="vm.user.preferredDfsEmail"
                     x-form="vm.submitForApprovalForm"
                     x-options='{
                         "title":"Divisional Financial Staff Email",
@@ -51,12 +54,14 @@
                         "id":"dfs",
                         "name":"dfs",
                         "placeholder":"firstname.lastname@gov.bc.ca"
-                    }'>
+                    }' 
+                    required>
                  </form-input>
 
                  <form-input
+                    type="email"
                     class="col-sm-12"
-                    ng-model="vm.user.preferredBfs"
+                    ng-model="vm.user.preferredBfsEmail"
                     x-form="vm.submitForApprovalForm"
                     x-options='{
                         "title":"Branch Financial Staff Email",
@@ -64,24 +69,15 @@
                         "id":"bfs",
                         "name":"bfs",
                         "placeholder":"firstname.lastname@gov.bc.ca"
-                    }'>
+                    }' 
+                    required>
                  </form-input>
-
-                <form-display
-                    class="col-sm-12"
-                    x-options='{
-                        "title":"Email Body",
-                        "name":"emailbody",
-                        "help":"Confirm/edit the email body below before submitting"
-                    }'>
-                    <textarea class="form-control" cols="30" rows="3"></textarea>
-                </form-display>
 	        </fieldset> 
 
 			<div class="edit-form-footer">
 				<div class="row">
 					<div class="col-xs-12">
-						<button ng-click="" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Send approval request"><i class="fa fa-save"></i> Submit</button>
+						<button ng-click="vm.submitForApproval(vm.submitForApprovalForm.$valid)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Send approval request"><i class="fa fa-save"></i> Submit</button>
 					</div>
 				</div>
 			</div>

--- a/modules/opportunities/client/views/cwu-opportunity-view.html
+++ b/modules/opportunities/client/views/cwu-opportunity-view.html
@@ -99,7 +99,7 @@
 			<div class="col-xs-12">
 				<div class="pull-right" role="group">
 					<button type="button" class="btn btn-sm btn-text-only" ng-if="vm.canEdit" ui-sref="opportunityadmin.editcwu({opportunityId:vm.opportunity.code})"><i class="fa fa-pencil"></i> EDIT</button>
-					<a href="javascript:void(0);" ng-if="vm.canPublish && vm.opportunity.project.isPublished && vm.canEdit && !vm.opportunity.isPublished" class="btn btn-sm btn-primary" ng-click="vm.publish(vm.opportunity, true)"><i class="fa fa-bullhorn"></i> PUBLISH</a>
+					<a href="javascript:void(0);" ng-if="vm.canPublish && vm.opportunity.project.isPublished && vm.canEdit && !vm.opportunity.isPublished" class="btn btn-sm btn-primary" ui-sref="opportunityadmin.submitcwu({opportunityId:vm.opportunity.code})"><i class="fa fa-bullhorn"></i> SUBMIT</a>
 				</div>
 			</div>
 		</div>

--- a/modules/opportunities/client/views/opportunity-list-directive.html
+++ b/modules/opportunities/client/views/opportunity-list-directive.html
@@ -39,11 +39,8 @@
 			<span class="label label-danger" ng-if="!opportunity.isPublished"><i class="fa fa-exclamation-triangle" ></i> UNPUBLISHED</span>
 			&nbsp;
 			<span class="label label-primary">Admin</span>
-			&nbsp;
 			<a ng-if="opportunity.project.isPublished && (vm.isAdmin || opportunity.userIs.admin) && opportunity.isPublished" href="javascript:void(0);" ng-click="vm.publish(opportunity, false); $event.stopPropagation()" uib-tooltip="Unpublish"><i class="glyphicon glyphicon-ban-circle"></i></a>
-			&nbsp;
-			<a ng-if="opportunity.project.isPublished && (vm.isAdmin || opportunity.userIs.admin) && !opportunity.isPublished" href="javascript:void(0);" ng-click="vm.publish(opportunity, true); $event.stopPropagation()" uib-tooltip="Publish"><i class="glyphicon glyphicon-check"></i>
-			</a>
+			<a ng-if="opportunity.project.isPublished && (vm.isAdmin || opportunity.userIs.admin) && !opportunity.isPublished" href="javascript:void(0);" ui-sref="opportunityadmin.submitcwu({ opportunityId: opportunity.code, projectId: vm.projectId })" ng-click="$event.stopPropagation()" uib-tooltip="Submit"><i class="glyphicon glyphicon-check"></i></a>
 			&nbsp;
 			<a ng-if="(vm.isAdmin || opportunity.userIs.admin) && opportunity.opportunityTypeCd==='code-with-us'" href="javascript:void(0);"  id="opportunityadmin.edit" ui-sref="opportunityadmin.editcwu({ opportunityId: opportunity.code, projectId: vm.projectId })" ng-click="$event.stopPropagation()" uib-tooltip="Edit"><i class="glyphicon glyphicon-edit"></i></a>
 			<a ng-if="(vm.isAdmin || opportunity.userIs.admin) && opportunity.opportunityTypeCd==='sprint-with-us'" href="javascript:void(0);"  id="opportunityadmin.edit" ui-sref="opportunityadmin.editswu({ opportunityId: opportunity.code, projectId: vm.projectId })" ng-click="$event.stopPropagation()" uib-tooltip="Edit"><i class="glyphicon glyphicon-edit"></i></a>

--- a/modules/opportunities/server/controllers/opportunities.server.controller.js
+++ b/modules/opportunities/server/controllers/opportunities.server.controller.js
@@ -927,3 +927,21 @@ exports.unPublishOpportunities = function (programId, projectId) {
 		}));
 	});
 };
+// -------------------------------------------------------------------------
+//
+// Send a notification email requesting approval for opportunity publication
+//
+// -------------------------------------------------------------------------
+exports.submitForApproval = function(req, res) {
+	Notifications.notifyUserAdHoc('opportunity-publish-approval', req.body).then(
+		function() {
+			res.json({
+				ok: true
+			});
+		}, 
+		function(error) {
+			res.status(500).json({
+				message: "Automailer error: " + error.code
+			});
+		});
+};

--- a/modules/opportunities/server/controllers/opportunities.server.controller.js
+++ b/modules/opportunities/server/controllers/opportunities.server.controller.js
@@ -938,10 +938,10 @@ exports.submitForApproval = function(req, res) {
 			res.json({
 				ok: true
 			});
-		}, 
+		},
 		function(error) {
 			res.status(500).json({
-				message: "Automailer error: " + error.code
+				message: 'Automailer error: ' + error.code
 			});
 		});
 };

--- a/modules/opportunities/server/models/opportunity.server.model.js
+++ b/modules/opportunities/server/models/opportunity.server.model.js
@@ -39,7 +39,7 @@ var OpportunitySchema = new Schema({
 	views                     : {type: Number, default: 1},
 	program                   : {type: Schema.ObjectId, ref: 'Program', default: null, required: 'Program cannot be blank'},
 	project                   : {type: Schema.ObjectId, ref: 'Project', default: null, required: 'Project cannot be blank'},
-	status                    : {type: String, default:'Pending', enum:['Pending', 'Assigned', 'In Progress', 'Completed']},
+	status                    : {type: String, default:'Pending', enum:['Draft', 'Pending', 'Assigned', 'In Progress', 'Completed']},
 	onsite                    : {type: String, default:'mixed', enum:['mixed', 'onsite', 'offsite']},
 	location                  : {type: String, default:''},
 	isPublished               : {type: Boolean, default: false},

--- a/modules/opportunities/server/routes/opportunities.server.routes.js
+++ b/modules/opportunities/server/routes/opportunities.server.routes.js
@@ -30,6 +30,12 @@ module.exports = function(app) {
 		.get(opportunities.forProgram);
 
 	//
+	//  submitting opportunities for publication
+	//
+	app.route('/api/opportunities/submit/for/approval')
+		.post(opportunities.submitForApproval);
+
+	//
 	// get lists of users
 	//
 	app.route('/api/opportunities/members/:opportunityId')

--- a/modules/users/server/controllers/admin.server.controller.js
+++ b/modules/users/server/controllers/admin.server.controller.js
@@ -70,6 +70,11 @@ exports.update = function (req, res) {
       user.capabilityDetails = req.body.capabilityDetails;
       user.capabilitySkills = req.body.capabilitySkills;
 
+  // Storing notification email addresses in user model
+  user.preferredAdmEmail = req.body.preferredAdmEmail;
+  user.preferredBfsEmail = req.body.preferredBfsEmail;
+  user.preferredDfsEmail = req.body.preferredDfsEmail;
+
 
 
 

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -61,7 +61,12 @@ var whitelistedFields = [
 	'isPublicProfile',
 	'isAutoAdd',
 	'capabilityDetails',
-	'capabilitySkills'
+	'capabilitySkills',
+
+	// Storing email address for submission on user profile
+	'preferredAdmEmail',
+	'preferredDfsEmail',
+	'preferredBfsEmail'
 
 ];
 
@@ -295,9 +300,11 @@ exports.me = function (req, res) {
 			linkedIn                : req.user.linkedIn,
 			isPublicProfile         : req.user.isPublicProfile,
 			isAutoAdd               : req.user.isAutoAdd,
-			capabilityDetails : req.user.capabilityDetails,
-			capabilitySkills : req.user.capabilitySkills
-
+			capabilityDetails 		: req.user.capabilityDetails,
+			capabilitySkills 		: req.user.capabilitySkills,
+			preferredAdmEmail		: req.user.preferredAdmEmail,
+			preferredBfsEmail		: req.user.preferredBfsEmail,
+			preferredDfsEmail		: req.user.preferredDfsEmail
 		};
 	}
 

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -151,9 +151,10 @@ var UserSchema = new Schema({
 	isAutoAdd         : {type: Boolean, default:true},
 	capabilities      : {type: [{type:Schema.ObjectId, ref: 'Capability'}], default:[]},
 	capabilitySkills  : {type: [{type:Schema.ObjectId, ref: 'CapabilitySkill'}], default:[]},
-	capabilityDetails : {type:[UserCapabilities], default:[]}
-
-
+	capabilityDetails : {type:[UserCapabilities], default:[]},
+	preferredAdmEmail : {type: String, default: ''},
+	preferredBfsEmail : {type: String, default: ''},
+	preferredDfsEmail : {type: String, default: ''}
 });
 
 /**


### PR DESCRIPTION
New workflow for notifying ADMs via email of pending opportunities on Code With Us.

* Newly created opportunities default to "Draft" status instead of "Pending" until notification is sent
* 'Publish' buttons on Opportunity List, View, and Edit pages are now 'Submit' buttons
* Submission is handled by a new view that allows ADM, BFS, and DFS emails to be provided
* New email template 'opportunity-publish-approval' has been added
* Previously used email addresses are stored with the user profile and are used to auto-populate the Submission view

Assumptions:
* Emails should be sent to ADM, BFS, and DFS (task indicated only ADM, but I assumed the others since that information was being collected)
* An opportunity can be submitted more than once, so I do not disable submission after a submit is completed
* Opportunity approval/rejection is out of scope for this challenge
* The new workflow applies only to CWU opportunities

License: https://github.com/BCDevExchange/devex/blob/develop/LICENSE

Fixes #236 