### PR TITLE
Bug Fixes

### DIFF
--- a/modules/core/client/directives/forms.client.directive.js
+++ b/modules/core/client/directives/forms.client.directive.js
@@ -349,18 +349,17 @@
 						return 'You are about to leave the page with unsaved data. Click Cancel to remain here.';
 					}
 				};
-				var $locationChangeStartUnbind = $scope.$on('$locationChangeStart', function(event, next, current) {
+				var $stateChangeStartUnbind = $scope.$on('$stateChangeStart', function(event, next, current) {
 					if ($scope.parentForm.$dirty) {
-						if ( !confirm('You are about to leave the page with unsaved data. Click Cancel to remain here.') ) {
-							// cancel to not allow.
+						if (!confirm('You are about to leave the page with unsaved data. Click Cancel to remain here.') ) {
+							// Stay on current route if user cancels.
 							event.preventDefault();
-							return false;
 						}
 					}
 				});
 				$scope.$on('destroy', function () {
 					window.onbeforeunload = null;
-					$locationChangeStartUnbind ();
+					$stateChangeStartUnbind();
 				})
 			}
 		};

--- a/modules/proposals/client/controllers/proposals.client.controller.js
+++ b/modules/proposals/client/controllers/proposals.client.controller.js
@@ -299,21 +299,21 @@
 			bodyText: 'You have unsaved changes. Changes will be discarded if you continue.'
 		};
 		var pristineProposal = angular.toJson (ppp.proposal);
-		var $locationChangeStartUnbind = $scope.$on ('$stateChangeStart', function (event, toState, toParams) {
-			if (pristineProposal !== angular.toJson (ppp.proposal) || pristineUser !== angular.toJson (ppp.user)) {
-				if (toState.retryInProgress) {
-					toState.retryInProgress = false;
-					return;
-				}
-				modalService.showModal ({}, saveChangesModalOpt)
-				.then(function  () {
-					toState.retryInProgress = true;
-					$state.go(toState, toParams);
-				}, function () {
-				});
-				event.preventDefault();
-			}
-		});
+		// var $locationChangeStartUnbind = $scope.$on ('$stateChangeStart', function (event, toState, toParams) {
+		// 	if (pristineProposal !== angular.toJson (ppp.proposal) || pristineUser !== angular.toJson (ppp.user)) {
+		// 		if (toState.retryInProgress) {
+		// 			toState.retryInProgress = false;
+		// 			return;
+		// 		}
+		// 		modalService.showModal ({}, saveChangesModalOpt)
+		// 		.then(function  () {
+		// 			toState.retryInProgress = true;
+		// 			$state.go(toState, toParams);
+		// 		}, function () {
+		// 		});
+		// 		event.preventDefault();
+		// 	}
+		// });
 		window.onbeforeunload = function() {
 			if (pristineProposal !== angular.toJson (ppp.proposal)) {
 				return 'onbeforeunload: You are about to leave the page with unsaved data. Click Cancel to remain here.';
@@ -321,7 +321,7 @@
 		};
 		$scope.$on('$destroy', function () {
 			window.onbeforeunload = null;
-			$locationChangeStartUnbind ();
+			// $locationChangeStartUnbind ();
 		});
 		// -------------------------------------------------------------------------
 		//
@@ -435,17 +435,21 @@
 		//
 		// -------------------------------------------------------------------------
 		ppp.close = function () {
-			if (pristineProposal !== angular.toJson (ppp.proposal)) {
-				modalService.showModal ({}, saveChangesModalOpt)
-				.then(function () {
-					window.onbeforeunload = null;
-					$locationChangeStartUnbind ();
-					$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
-				}, function () {
-				});
-			} else {
-				$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
+			if (pristineProposal === angular.toJson (ppp.proposal)) {
+				window.onbeforeunload = null;
 			}
+			$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
+			// if (pristineProposal !== angular.toJson (ppp.proposal)) {
+			// 	modalService.showModal ({}, saveChangesModalOpt)
+			// 	.then(function () {
+			// 		window.onbeforeunload = null;
+			// 		$locationChangeStartUnbind ();
+			// 		$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
+			// 	}, function () {
+			// 	});
+			// } else {
+			// 	$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
+			// }
 		};
 		// -------------------------------------------------------------------------
 		//

--- a/modules/proposals/client/controllers/proposals.client.controller.js
+++ b/modules/proposals/client/controllers/proposals.client.controller.js
@@ -22,7 +22,6 @@
 		ppp.user          = ppp.proposal.user;
 		ppp.opportunity   = ppp.proposal.opportunity;
 		ppp.detail        = $sce.trustAsHtml(ppp.proposal.detail);
-		console.log (ppp.proposal);
 		ppp.capabilities                          = capabilities;
 		//
 		// what type of opportunity is this? this will determine what tabs get shown
@@ -81,7 +80,6 @@
 					});
 				}
 			});
-			console.log (ppp.clist);
 		}
 		// -------------------------------------------------------------------------
 		//
@@ -216,16 +214,13 @@
 					});
 				}
 			});
-			console.log (ppp.clist);
 			//
 			// now gather up ONLY those folks who have at least one of the required capabilities
 			// this should include any current team members
 			//
 			ppp.winners = [];
-			console.log ('team:' , ppp.proposal.team);
 			ppp.members.forEach (function (member) {
 				member.selected = isInArray (ppp.proposal.team.map(function(a){return a._id;}), member._id);
-				console.log (member._id, member.selected);
 				//
 				// add up their scores on all required capabilities, if > 0 include them
 				//
@@ -236,7 +231,6 @@
 				});
 				if (score > 0) ppp.winners.push (member);
 			});
-			console.log (ppp.winners);
 		}
 		// -------------------------------------------------------------------------
 		//
@@ -265,10 +259,8 @@
 							accum[1] + elem[1]
 						];
 					}, [false, 0]);
-					// console.log (row.code, scores);
 					row.minMet = scores[0];
 					row.desMet = scores[1] >= row.desYears;
-			console.log (row);
 			});
 		};
 		ppp.calculateScores ();
@@ -299,30 +291,6 @@
 			bodyText: 'You have unsaved changes. Changes will be discarded if you continue.'
 		};
 		var pristineProposal = angular.toJson (ppp.proposal);
-		// var $locationChangeStartUnbind = $scope.$on ('$stateChangeStart', function (event, toState, toParams) {
-		// 	if (pristineProposal !== angular.toJson (ppp.proposal) || pristineUser !== angular.toJson (ppp.user)) {
-		// 		if (toState.retryInProgress) {
-		// 			toState.retryInProgress = false;
-		// 			return;
-		// 		}
-		// 		modalService.showModal ({}, saveChangesModalOpt)
-		// 		.then(function  () {
-		// 			toState.retryInProgress = true;
-		// 			$state.go(toState, toParams);
-		// 		}, function () {
-		// 		});
-		// 		event.preventDefault();
-		// 	}
-		// });
-		window.onbeforeunload = function() {
-			if (pristineProposal !== angular.toJson (ppp.proposal)) {
-				return 'onbeforeunload: You are about to leave the page with unsaved data. Click Cancel to remain here.';
-			}
-		};
-		$scope.$on('$destroy', function () {
-			window.onbeforeunload = null;
-			// $locationChangeStartUnbind ();
-		});
 		// -------------------------------------------------------------------------
 		//
 		// team score
@@ -431,17 +399,6 @@
 		// -------------------------------------------------------------------------
 		ppp.close = function() {
 			$state.go('opportunities.view', {opportunityId:ppp.opportunity.code});
-			// if (pristineProposal !== angular.toJson (ppp.proposal)) {
-			// 	modalService.showModal ({}, saveChangesModalOpt)
-			// 	.then(function () {
-			// 		window.onbeforeunload = null;
-			// 		$locationChangeStartUnbind ();
-			// 		$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
-			// 	}, function () {
-			// 	});
-			// } else {
-			// 	$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
-			// }
 		};
 		// -------------------------------------------------------------------------
 		//

--- a/modules/proposals/client/controllers/proposals.client.controller.js
+++ b/modules/proposals/client/controllers/proposals.client.controller.js
@@ -397,37 +397,32 @@
 		// save the proposal - promise
 		//
 		// -------------------------------------------------------------------------
-		var saveproposal = function (goodmessage, badmessage) {
-			copyuser ();
-			copyteam ();
-			return new Promise (function (resolve, reject) {
-				ppp.proposal.createOrUpdate ()
-				.then (
-					function (response) {
-						Notification.success({ message: goodmessage || '<i class="glyphicon glyphicon-ok"></i> Your changes have been saved.'});
-						ppp.proposal = response;
-						pristineProposal = angular.toJson (ppp.proposal);
-						ppp.subscribe (true);
-						resolve ();
-					},
-					function (error) {
-						 Notification.error ({ message: badmessage || error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Edit Proposal failed!' });
-						 reject ();
-					}
-				);
-			});
+		var saveproposal = function(goodmessage, badmessage) {
+			copyuser();
+			copyteam();
+			return ppp.proposal.createOrUpdate()
+				.then (function(proposal) {
+					Notification.success({message: goodmessage || '<i class="glyphicon glyphicon-ok"></i> Your changes have been saved.'});
+					ppp.proposal = proposal;
+					pristineProposal = angular.toJson(ppp.proposal);
+					ppp.subscribe(true);
+					ppp.form.proposalform.$setPristine();
+				}, function (error) {
+					Notification.error ({ message: badmessage || error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Edit Proposal failed!'});
+				});
 		};
 		// -------------------------------------------------------------------------
 		//
 		// perform the save, both user info and proposal info
 		//
 		// -------------------------------------------------------------------------
-		ppp.save = function (isvalid) {
+		ppp.save = function(isvalid) {
 			if (!isvalid) {
 				$scope.$broadcast('show-errors-check-validity', 'ppp.form.proposalform');
 				return false;
 			}
-			saveuser().then (saveproposal);
+			saveuser()
+				.then(saveproposal);
 		};
 		// -------------------------------------------------------------------------
 		//
@@ -469,9 +464,12 @@
 					}
 				});
 		};
-		var performwithdrawal = function (txt) {
-					ppp.proposal.status = 'Draft';
-					saveuser().then (function () {saveproposal ('Your proposal has been withdrawn.')});
+		var performwithdrawal = function(txt) {
+			ppp.proposal.status = 'Draft';
+			saveuser()
+				.then(function() {
+					saveproposal('Your proposal has been withdrawn.');
+				});
 		};
 		// -------------------------------------------------------------------------
 		//
@@ -486,8 +484,8 @@
 		// this deletes a submission
 		//
 		// -------------------------------------------------------------------------
-		ppp.withdraw = function () {
-			performwithdrawal ();
+		ppp.withdraw = function() {
+			performwithdrawal();
 		};
 		// -------------------------------------------------------------------------
 		//

--- a/modules/proposals/client/controllers/proposals.client.controller.js
+++ b/modules/proposals/client/controllers/proposals.client.controller.js
@@ -434,11 +434,8 @@
 		// leave without saving any work
 		//
 		// -------------------------------------------------------------------------
-		ppp.close = function () {
-			if (pristineProposal === angular.toJson (ppp.proposal)) {
-				window.onbeforeunload = null;
-			}
-			$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
+		ppp.close = function() {
+			$state.go('opportunities.view', {opportunityId:ppp.opportunity.code});
 			// if (pristineProposal !== angular.toJson (ppp.proposal)) {
 			// 	modalService.showModal ({}, saveChangesModalOpt)
 			// 	.then(function () {
@@ -497,20 +494,19 @@
 		// submit the proposal
 		//
 		// -------------------------------------------------------------------------
-		ppp.submit = function () {
-			saveuser().then (function () {
-				copyuser ();
-				ProposalsService.submit (ppp.proposal).$promise
-				.then (
-					function (response) {
-						ppp.proposal = response;
-						Notification.success({ message: '<i class="glyphicon glyphicon-ok"></i> Your proposal has been submitted!'});
-					},
-					function (error) {
-						 Notification.error ({ message: error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Error Submitting Proposal' });
-					}
-				);
-			});
+		ppp.submit = function() {
+			saveuser()
+				.then(function() {
+					copyuser();
+					ppp.proposal.$submit()
+						.then (function(proposal) {
+							ppp.proposal = proposal;
+							ppp.form.proposalform.$setPristine();
+							Notification.success({message: '<i class="glyphicon glyphicon-ok"></i> Your proposal has been submitted!'});
+						}, function(error) {
+							Notification.error ({message: error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Error Submitting Proposal'});
+						});
+				});
 		}
 		// -------------------------------------------------------------------------
 		//

--- a/modules/proposals/client/controllers/proposals.client.controller.js
+++ b/modules/proposals/client/controllers/proposals.client.controller.js
@@ -457,21 +457,20 @@
 		// function is a boolean as to whether or not to perform the action
 		//
 		// -------------------------------------------------------------------------
-		var performdelete = function (q) {
-			ask.yesNo (q).then (function (r) {
-				if (r) {
-					ppp.proposal.$remove (
-						function () {
-							Notification.success({ message: '<i class="glyphicon glyphicon-ok"></i> Remove Proposal successful'});
-							ppp.subscribe (false);
-							$state.go ('opportunities.view',{opportunityId:ppp.opportunity.code});
-						},
-						function (error) {
-							 Notification.error ({ message: error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Remove Proposal failed!' });
-						}
-					);
-				}
-			});
+		var performdelete = function(q) {
+			ask.yesNo(q)
+				.then(function(r) {
+					if (r) {
+						ppp.proposal.$remove(function() {
+							Notification.success({message: '<i class="glyphicon glyphicon-ok"></i> Remove Proposal successful'});
+							ppp.subscribe(false);
+							ppp.form.proposalform.$setPristine();
+							$state.go('opportunities.view', {opportunityId:ppp.opportunity.code});
+						}, function(error) {
+							Notification.error({message: error.data.message, title: '<i class="glyphicon glyphicon-remove"></i> Remove Proposal failed!'});
+						});
+					}
+				});
 		};
 		var performwithdrawal = function (txt) {
 					ppp.proposal.status = 'Draft';
@@ -482,8 +481,8 @@
 		// this deletes a draft
 		//
 		// -------------------------------------------------------------------------
-		ppp.delete = function () {
-			performdelete ('Are you sure you want to delete your proposal? All your work will be lost. There is no undo for this!');
+		ppp.delete = function() {
+			performdelete('Are you sure you want to delete your proposal? All your work will be lost. There is no undo for this!');
 		};
 		// -------------------------------------------------------------------------
 		//

--- a/modules/proposals/client/views/edit-proposal.client.view.html
+++ b/modules/proposals/client/views/edit-proposal.client.view.html
@@ -32,7 +32,7 @@
 
 
 
-<form id="proposalform" name="ppp.form.proposalform" class="form" ng-submit="ppp.save(ppp.form.proposalform.$valid)" novalidate>
+<form id="proposalform" name="ppp.form.proposalform" class="form" ng-submit="ppp.save(ppp.form.proposalform.$valid)" novalidate warn-on-exit>
 
 <section>
 	<div class="row" ng-if="!ppp.isSprintWithUs">


### PR DESCRIPTION
fix(proposals): Fixes high priority bugs with Unsaved Changes Modal

Adds `warn-on-exit` directive to proposal form.
Updates `warnOnExit` scope listeners so URL and state changes are correctly intercepted and handled.
Updates proposal form controller to reset pristine state whenever actions such as `save`, `delete`, `submit` and `withdraw` are performed.
Removes deprecated modal logic from proposal form controller since directive now handles confirmation prompts.

Fixes #187, Fixes #188