### PR TITLE
[Code Challenge #249]: Created workflow for ADM publish opportunity

### DIFF
--- a/modules/core/server/email_templates/opportunity-publish-notification-body.md
+++ b/modules/core/server/email_templates/opportunity-publish-notification-body.md
@@ -1,14 +1,15 @@
 {{#markdown this}}
 ![BC Dev Exchange](https://bcdevexchange.org/modules/core/client/img/logo/new-logo-220px.png)
 
-A new *Code With Us* opportunity is pending and awaiting your approval.  Please review the information below, and choose *Agree* or *Disagree* to approve or deny publication of the opportunity.
+A *Code With Us* opportunity was approved and is now published.  For your information, the details of the opportunity are summarized below.
 
-### {{ data.opportunityId }}
+### {{ data.opportunityTitle }}
 
-- Associated RFP Control: **{{ data.rfp }}**
+- Contract manager: **{{ data.contractManager }}**
+- Unique ID: **{{ data.bcDevExUniqueId }}**
 - Posting Date: **{{ data.postingDate }}**
 - Value: **${{ data.value }}**
-- Required Skills: **{{ data.requiredSkills }}**
+- Start Date: **{{ data.startDate }}**
 - Closing Date: **{{ data.closingDate }}**
 
 ---
@@ -28,7 +29,3 @@ A new *Code With Us* opportunity is pending and awaiting your approval.  Please 
         border-left: 1px solid #CCCCCC;
     }
 </style>
-<div width=100% align=center>
-    <a href="https://bcdevexchange.org/opportunityadmin/publishcwu">Agree</a>&nbsp;&nbsp;
-    <a href="https://bcdevexchange.org/path/to/opp/deny">Disagree</a>
-</div>

--- a/modules/opportunities/client/config/opportunities.client.routes.js
+++ b/modules/opportunities/client/config/opportunities.client.routes.js
@@ -250,6 +250,32 @@
 		})
 		// -------------------------------------------------------------------------
 		//
+		// Opportunity publication
+		//
+		// -------------------------------------------------------------------------
+		.state('opportunityadmin.publishcwu', {
+			url: '/:opportunityId/publishcwu',
+			templateUrl: '/modules/opportunities/client/views/cwu-opportunity-publish.html',
+			controller: 'OpportunityPublishController',
+			controllerAs: 'vm',
+			resolve: {
+				opportunity: function ($stateParams, OpportunitiesService) {
+					return OpportunitiesService.get({
+						opportunityId: $stateParams.opportunityId
+					}).$promise;
+				}
+			},
+			data: {
+				roles: ['admin', 'gov'],
+				pageTitle: 'Opportunity: {{ opportunity.name }}'
+			},
+			ncyBreadcrumb: {
+				label: 'Opportunity',
+				parent: 'opportunities.list'
+			}
+		})
+		// -------------------------------------------------------------------------
+		//
 		// edit a opportunity
 		//
 		// -------------------------------------------------------------------------

--- a/modules/opportunities/client/views/cwu-opportunity-publish.html
+++ b/modules/opportunities/client/views/cwu-opportunity-publish.html
@@ -1,0 +1,41 @@
+<!-- Persistent banner for Opportunity Creators -->
+<div class="banner banner-important" >
+	<div class="container">
+		<div class="row">
+			<div class="col-xs-12">
+				<p>By posting an opportunity on the BCDevExchange, you are agreeing to follow the <a href="/api/proposals/download/terms/cwu1" target="_blank"><i class="fa fa-download"></i> terms</a> of our lightweight procurement model, Code With Us. Make sure you're familiar with the process and understand your responsibilities for managing an opportunity. <a href="https://github.com/BCDevExchange/code-with-us/wiki/2.-For-Public-Sector-Employees:-How-to-Manage-a-Code-With-Us-Opportunity" target="_blank">Read the guide</a></p>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+<section class="edit-form-background" role="main">
+
+	<form id="opportunityPublishForm" name="vm.opportunityPublishForm" class="form" novalidate>
+
+		<div class="container edit-form">
+
+			<div class="edit-form-header">
+                <span>
+                    <span class="light small">
+                        SUBMITTING:
+                    </span>
+                    {{vm.opportunity.name}}
+                </span>
+
+				<a ui-sref="opportunities.viewcwu({opportunityId:vm.opportunity.code})" ng-if="vm.opportunity._id" class="btn btn-text-only pull-right" title="Close"><i class="fa fa-2x fa-times"></i></a>
+                <a ui-sref="opportunities.list()" ng-if="!vm.opportunity._id" class="btn btn-text-only pull-right"><i class="fa fa-2x fa-times" title="Close"></i></a>
+			</div>
+	        </fieldset> 
+
+			<div class="edit-form-footer">
+				<div class="row">
+					<div class="col-xs-12">
+						<button ng-click="vm.opportunityPublish(vm.opportunityPublishForm.$valid)" href-"javascript:void(0);" class="btn btn-primary pull-right" title="Publish Opportunity"><i class="fa fa-bullhorn"></i> Submit</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</form>
+</section>

--- a/modules/opportunities/server/models/opportunity.server.model.js
+++ b/modules/opportunities/server/models/opportunity.server.model.js
@@ -39,7 +39,7 @@ var OpportunitySchema = new Schema({
 	views                     : {type: Number, default: 1},
 	program                   : {type: Schema.ObjectId, ref: 'Program', default: null, required: 'Program cannot be blank'},
 	project                   : {type: Schema.ObjectId, ref: 'Project', default: null, required: 'Project cannot be blank'},
-	status                    : {type: String, default:'Pending', enum:['Draft', 'Pending', 'Assigned', 'In Progress', 'Completed']},
+	status                    : {type: String, default:'Pending', enum:['Draft', 'Pending', 'Published', 'Assigned', 'In Progress', 'Completed']},
 	onsite                    : {type: String, default:'mixed', enum:['mixed', 'onsite', 'offsite']},
 	location                  : {type: String, default:''},
 	isPublished               : {type: Boolean, default: false},


### PR DESCRIPTION
Code Challenge (Opportunity Publish): Created workflow for ADM publish opportunity

Responding to [feature change request #249](https://github.com/BCDevExchange/devex/issues/249) from Paul Roberts. 

Added new opportunity status called 'Published' to model. 

Changed behaviour of ADM 'Agree' button in publish approval email.

On 'Agree' press it opens a page to publish opportunity.

After publishing it notifies:
1. the Program Area Manager, 
2. the Branch Financial Staff, and
3. the Divisional Financial Staff.  

Scope was:
1. the opportunities controller, view, routing and model, and
2. two server email templates were changed in the core.

Features #249 

[Apache License 2.0.txt](https://github.com/BCDevExchange/devex/files/1846312/Apache.License.2.0.txt)

