### PR TITLE
BA-728 Double list during invite or delete members

### DIFF
--- a/modules/orgs/client/controllers/orgs.client.controller.js
+++ b/modules/orgs/client/controllers/orgs.client.controller.js
@@ -255,16 +255,23 @@
 			// $rootScope.$broadcast('updateOrg', 'done');
 			vm.orgForm.$setPristine ();
 			vm.emaillist = '';
-			OrgsService.get ({orgId: vm.org._id}).$promise
+			var id = vm.org._id;
+			vm.loading = true;
+			OrgsService.get ({orgId: id}).$promise
 			.then (function (org) {
 				vm.org = org;
 				CapabilitiesMethods.init (vm, vm.org, capabilities);
 				// $rootScope.$broadcast('updateOrg', 'done');
+				vm.loading = false;
 			});
 		};
 		// -------------------------------------------------------------------------
 		//
 		// add or remove members
+		// CC: swap out the reference here.  this does create a new reference and
+		// orphans the original, but since all we do on this screen is this action
+		// it really makes little difference.  If change was afffected immediately
+		// then this would be an issue
 		//
 		// -------------------------------------------------------------------------
 		vm.addMembers = function () {

--- a/modules/orgs/client/controllers/orgs.client.controller.js
+++ b/modules/orgs/client/controllers/orgs.client.controller.js
@@ -252,14 +252,14 @@
 		//
 		// -------------------------------------------------------------------------
 		vm.refresh = function () {
-			$rootScope.$broadcast('updateOrg', 'done');
+			// $rootScope.$broadcast('updateOrg', 'done');
 			vm.orgForm.$setPristine ();
 			vm.emaillist = '';
 			OrgsService.get ({orgId: vm.org._id}).$promise
 			.then (function (org) {
 				vm.org = org;
 				CapabilitiesMethods.init (vm, vm.org, capabilities);
-				$rootScope.$broadcast('updateOrg', 'done');
+				// $rootScope.$broadcast('updateOrg', 'done');
 			});
 		};
 		// -------------------------------------------------------------------------
@@ -270,25 +270,29 @@
 		vm.addMembers = function () {
 			vm.orgForm.$setPristine ();
 			if (vm.emaillist !== '') {
-				vm.org.additions = vm.emaillist;
-				vm.org.createOrUpdate ()
+				var saveorg = new OrgsService (vm.org);
+				saveorg.additions = vm.emaillist;
+				saveorg.$update ()
+				.then (function (savedOrg) {
+					// vm.org = savedOrg;
+					vm.emaillist = '';
+					// CapabilitiesMethods.init (vm, vm.org, capabilities);
+					// vm.refresh ();
+					vm.orgForm.$setPristine ();
+					// $rootScope.$broadcast('updateOrg', 'done');
+					return savedOrg;
+				})
 				.then (vm.displayResults)
 				//
 				// fail, notify and stay put
 				//
-				.then (function () {
-					vm.emaillist = '';
-					CapabilitiesMethods.init (vm, vm.org, capabilities);
-					vm.refresh ();
-					vm.orgForm.$setPristine ();
-					$rootScope.$broadcast('updateOrg', 'done');
-				})
 				.catch (function (res) {
 					Notification.error ({
 						message : res.message,
 						title   : '<i class=\'glyphicon glyphicon-remove\'></i> invitations send error!'
 					});
-				});
+				})
+				;
 			}
 		};
 		vm.removeMember = function (member) {

--- a/modules/orgs/client/views/org-members.html
+++ b/modules/orgs/client/views/org-members.html
@@ -13,18 +13,20 @@
 				</div>
 				<span class="small gray-light">Add multiple emails separated with a comma.</span>
 				<h5>My Members:</h5>
-				<!-- // Update logic about when this alert appears if necessary .... should appear until there are 2 members in the list, then disappear // -->
-				<div ng-cloak class="alert alert-warning" ng-if="vm.org.members.length<2">
-					<i class="fa fa-lg fa-exclamation-circle"></i> &nbsp;You need at least 2 team members
-				</div>
-				<div ng-cloak class="card card-user" ng-repeat="member in vm.org.members">
-					<avatar-display url="member.profileImageURL" text="member.displayName"></avatar-display>
-					<button class="btn btn-text-only pull-right btn-remove" ng-click="vm.removeMember(member)" title="Remove member"><i class="fa fa-lg fa-times"></i></button>
-					<div class="card-body">
-						<label-list>
-							<label ng-repeat="capability in member.capabilities" class="label label-cap-default {{capability.labelClass}}"><i class="fa fa-circle"></i> {{capability.name}}</label>
-							<label ng-repeat="capabilitySkill in member.capabilitySkills" class="label label-preferred-skill">{{capabilitySkill.name}}</label>
-						</label-list>
+				<div ng-cloak ng-if="!vm.loading">
+					<!-- // Update logic about when this alert appears if necessary .... should appear until there are 2 members in the list, then disappear // -->
+					<div ng-cloak class="alert alert-warning" ng-if="vm.org.members.length<2">
+						<i class="fa fa-lg fa-exclamation-circle"></i> &nbsp;You need at least 2 team members
+					</div>
+					<div ng-cloak class="card card-user" ng-repeat="member in vm.org.members">
+						<avatar-display url="member.profileImageURL" text="member.displayName"></avatar-display>
+						<button class="btn btn-text-only pull-right btn-remove" ng-click="vm.removeMember(member)" title="Remove member"><i class="fa fa-lg fa-times"></i></button>
+						<div class="card-body">
+							<label-list>
+								<label ng-cloak ng-repeat="capability in member.capabilities" class="label label-cap-default {{capability.labelClass}}"><i class="fa fa-circle"></i> {{capability.name}}</label>
+								<label ng-cloak ng-repeat="capabilitySkill in member.capabilitySkills" class="label label-preferred-skill">{{capabilitySkill.name}}</label>
+							</label-list>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/modules/orgs/client/views/org-members.html
+++ b/modules/orgs/client/views/org-members.html
@@ -1,5 +1,5 @@
 <div class="edit-form-tab-content">
-	<form name="vm.orgForm" warn-on-exit id="vm.orgForm" novalidate autocomplete="off">
+	<form ng-cloak name="vm.orgForm" warn-on-exit id="vm.orgForm" novalidate autocomplete="off">
 		<div class="row">
 			<div class="col-xs-12 col-sm-7">
 				<p>This is where you make your Statement of Qualifications which will comprise your Response to the RFQ.</p>
@@ -14,10 +14,10 @@
 				<span class="small gray-light">Add multiple emails separated with a comma.</span>
 				<h5>My Members:</h5>
 				<!-- // Update logic about when this alert appears if necessary .... should appear until there are 2 members in the list, then disappear // -->
-				<div class="alert alert-warning" ng-if="vm.org.members.length<2">
+				<div ng-cloak class="alert alert-warning" ng-if="vm.org.members.length<2">
 					<i class="fa fa-lg fa-exclamation-circle"></i> &nbsp;You need at least 2 team members
 				</div>
-				<div class="card card-user" ng-repeat="member in vm.org.members">
+				<div ng-cloak class="card card-user" ng-repeat="member in vm.org.members">
 					<avatar-display url="member.profileImageURL" text="member.displayName"></avatar-display>
 					<button class="btn btn-text-only pull-right btn-remove" ng-click="vm.removeMember(member)" title="Remove member"><i class="fa fa-lg fa-times"></i></button>
 					<div class="card-body">
@@ -37,7 +37,7 @@
 				</div>
 				<table class="table capabilities-list">
 					<tbody>
-						<tr ng-repeat="capability in vm.capabilities">
+						<tr ng-cloak ng-repeat="capability in vm.capabilities">
 							<th scope="row" ng-if="vm.iOppCapabilities[capability.code]"><i class="fa fa-check-circle-o fa-2x success"></i></th>
 							<th scope="row" ng-if="!vm.iOppCapabilities[capability.code]"><i class="fa fa-circle-o fa-2x gray-light"></i></th>
 							<td><label class="label label-lg label-cap-default {{capability.labelClass}}">{{capability.name}}</label></td>


### PR DESCRIPTION
Fixed the invite side by swapping references and never allowing them to swap back.  This is *ok* because the list doesn't change from the operation immediately, so it doesn't matter that it doesn't properly refresh.  
The delete side is more messy because we want a refresh. We could do this with a splice and never reload the model - in fact, that might be a lot better than what I did - oh well. What I did was to do a silly loading hack and prevent the div from displaying until finished