### PR TITLE
BA-827 // Fix overlapping alerts on Pricing tab of SWU proposal.

### DIFF
--- a/modules/proposals/client/views/swu-proposal-edit.html
+++ b/modules/proposals/client/views/swu-proposal-edit.html
@@ -490,13 +490,11 @@
 													ng-blur="ppp.validateInceptionAmount()"
 													select-on-click>
 										</div>
-									</div>
-								</div>
-							</div>
-							<div class="proposal-amount-wrapper">
-								<span 	class="proposal-amount-error alert alert-danger"
+                                        <span 	class="proposal-amount-error alert alert-danger"
 										ng-if="ppp.proposal.phases.inception.invalidAmount">
 										<i class="fa fa-exclamation-triangle"></i> Your price for this phase must not exceed <strong>{{ppp.inceptionMax | currency}}</strong></span>
+									</div>
+								</div>
 							</div>
 						</div>
 
@@ -531,12 +529,10 @@
 													  placeholder=0.00
 													  select-on-click>
 										</div>
+                                        <span 	class="proposal-amount-error alert alert-danger"
+										ng-if="ppp.proposal.phases.proto.invalidAmount"><i class="fa fa-exclamation-triangle"></i> Your price for this phase must not exceed <strong>{{ppp.protoMax | currency}}</strong></span>
 									</div>
 								</div>
-							</div>
-							<div class="proposal-amount-wrapper">
-								<span 	class="proposal-amount-error alert alert-danger"
-										ng-if="ppp.proposal.phases.proto.invalidAmount"><i class="fa fa-exclamation-triangle"></i> Your price for this phase must not exceed <strong>{{ppp.protoMax | currency}}</strong></span>
 							</div>
 						</div>
 
@@ -570,14 +566,13 @@
 										  select-on-click
 										  ng-blur="ppp.validateImplementationAmount()">
 										</div>
+                                        <span 	class="proposal-amount-error alert alert-danger"
+                                                ng-if="ppp.proposal.phases.implementation.invalidAmount">
+                                                <i class="fa fa-exclamation-triangle"></i> Your price for this phase must not exceed <strong>{{ppp.implMax | currency}}</strong>
+                                        </span>
 									</div>
 								</div>
 							</div>
-						</div>
-						<div class="proposal-amount-wrapper">
-							<span 	class="proposal-amount-error alert alert-danger"
-									ng-if="ppp.proposal.phases.implementation.invalidAmount">
-									<i class="fa fa-exclamation-triangle"></i> Your price for this phase must not exceed <strong>{{ppp.implMax | currency}}</strong></span>
 						</div>
 					</div>
 


### PR DESCRIPTION
Fixes BA-827.
- moved the alerts inside the panel body to prevent the alert for the Implementation phase to overlap the Total Proponent Cost.