### PR TITLE
BA-845 // set form-control height so that inputs of type="date" do no…

### DIFF
--- a/public/less/include/bc-devx.less
+++ b/public/less/include/bc-devx.less
@@ -743,14 +743,15 @@ form-title {
 .form-control {
   font-size: 14px !important;
   padding: 10px;
-  height: auto;
+  height: 42px;
 }
 
 /* Size input-groups and their buttons in px instead of em so they align with the form-control */
 .input-group-btn {
   > .btn {
     font-size: 13px !important;
-    padding: 11px;  
+    padding: 11px;
+    border-color: #ccc;  
   }
 }
 


### PR DESCRIPTION
…t display larger than other inputs.

fix(public): Set form-control height so that date inputs don't become higher than other inputs.

@scchapma - Please see Jira ticket for details.

Fixes BA-845
