### PR TITLE
BA-876 // Hotfix: improve usability of team selection list

### DIFF
--- a/modules/proposals/client/css/proposals.css
+++ b/modules/proposals/client/css/proposals.css
@@ -17,7 +17,8 @@
 	min-width: 160px;
 }
 .team-selection-wrapper {
-	height: 235px;
+	max-height: 330px;
+	overflow-y: scroll;
 }
 .pagination-wrapper {
 	display: flex;


### PR DESCRIPTION
- Increase height of the team selection wrapper so that it will show (not hide) up to approx 7-8 team members per phase.
- Change height to max-height (so that if fewer than 7-8 members exist, the wrapper will fit to the contents instead of extra white space
- add scrolling so that if more members exist than fit in the view, the user can scroll to see that they are still there selected.

@SteveChapmanBCDX  - this is an urgent hotfix in response to a usability issue that was pointed out to me today. Can you please review and merge to develop then master?