### PR TITLE
BA-760 Fix broken build due to Node version check

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -59,7 +59,7 @@ fi
 
 echo "---> Installing all dependencies"
 npm install yarn -g -q
-yarn install  --non-interactive --pure-lockfile
+yarn install --non-interactive --pure-lockfile --ignore-engines
 
 # Do not fail when there is no build script
 echo "---> Building your Node application from source"


### PR DESCRIPTION
* Node8 image provided by Red Hat is 8.9.4 but some deps want 8.10+
* Run `yarn install --ignore-engines` to ignore the check
