### PR TITLE
feature/BA-764

### DIFF
--- a/modules/orgs/client/controllers/orgs.client.controller.js
+++ b/modules/orgs/client/controllers/orgs.client.controller.js
@@ -332,7 +332,7 @@
 					controller: function ($scope, $uibModalInstance) {
 						$scope.data = {
 							found    : result.emaillist.found,
-							notfound : result.emaillist.notfound
+							notfound : result.emaillist.notFound
 						};
 						$scope.close = function () {
 							$uibModalInstance.close ();

--- a/modules/orgs/server/controllers/orgs.server.controller.js
+++ b/modules/orgs/server/controllers/orgs.server.controller.js
@@ -713,24 +713,21 @@ exports.addUserToOrg = function (req, res) {
 	req.user = req.model;
 	var org = req.org;
 	var user = req.user;
-	// var orgO = org.toObject();
-	// var userO = user.toObject();
+
 	if (req.params.actionCode === 'decline') {
-		return res.status (200).json ({
+		return res.status(200).json ({
 			message: '<h4>Declined</h4>Thank you, you have not been added to company '+org.name
 		});
 	}
 	else {
 		// The user accepting the invitation must be recorded by id if they were an existing user at time of invite or by email if they had not yet registered
-		if (org.invitedUsers &&
-			org.invitedNonUsers &&
-			(org.invitedUsers.map(function(invitedUser) { return invitedUser.id; }).indexOf(user.id) !== -1) ||
-			(org.invitedNonUsers.map(function(invitedNonUser) { return invitedNonUser.email; }).indexOf(user.email) !== -1)) {
-			Promise.resolve (user)
-			.then (addUserTo (org, 'members'))
-			.then (saveUser)
-			.then (function () { return org; })
-			.then (saveOrgReturnMessage (req, res));
+		if ((org.invitedUsers && org.invitedUsers.map(function(invitedUser) { return invitedUser.id; }).indexOf(user.id) !== -1) ||
+			(org.invitedNonUsers && org.invitedNonUsers.map(function(invitedNonUser) { return invitedNonUser.email; }).indexOf(user.email) !== -1)) {
+			Promise.resolve(user)
+			.then(addUserTo (org, 'members'))
+			.then(saveUser)
+			.then(function() { return org; })
+			.then(saveOrgReturnMessage(req, res));
 		}
 		else {
 			return res.status(200).json({

--- a/modules/orgs/server/controllers/orgs.server.controller.js
+++ b/modules/orgs/server/controllers/orgs.server.controller.js
@@ -721,15 +721,21 @@ exports.addUserToOrg = function (req, res) {
 		});
 	}
 	else {
-		// return res.status (200).json ({
-		// 	message: '<h4>Accepted</h4>Thank you, you have been added to company '+org.name
-		// });
-		if (org.invitedUsers && org.invitedUsers.map(function(invitedUser) { return invitedUser.id; }).indexOf(user.id) !== -1) {
+		// The user accepting the invitation must be recorded by id if they were an existing user at time of invite or by email if they had not yet registered
+		if (org.invitedUsers &&
+			org.invitedNonUsers &&
+			(org.invitedUsers.map(function(invitedUser) { return invitedUser.id; }).indexOf(user.id) !== -1) ||
+			(org.invitedNonUsers.map(function(invitedNonUser) { return invitedNonUser.email; }).indexOf(user.email) !== -1)) {
 			Promise.resolve (user)
 			.then (addUserTo (org, 'members'))
 			.then (saveUser)
 			.then (function () { return org; })
 			.then (saveOrgReturnMessage (req, res));
+		}
+		else {
+			return res.status(200).json({
+				message: '<h4>Invalid Invitation</h4>Your invitation has either expired or is invalid.  Please ask your company admin to reissue you another invite.'
+			});
 		}
 	}
 };

--- a/modules/orgs/server/models/org.server.model.js
+++ b/modules/orgs/server/models/org.server.model.js
@@ -17,6 +17,10 @@ var validateLocalStrategyEmail = function (email) {
 // Org
 //
 // -------------------------------------------------------------------------
+var InvitedNonUserSchema = new Schema({
+	email: {type: String, default: ''}
+});
+
 var OrgSchema = new Schema ({
 	name                 : {type: String, default: '', required: 'Name cannot be blank'},
 	dba                  : {type: String, default: ''},
@@ -48,7 +52,9 @@ var OrgSchema = new Schema ({
 	updatedBy            : {type: 'ObjectId', ref: 'User', default: null },
 	members              : {type: [{ type: Schema.Types.ObjectId, ref: 'User' }], default: [] },
 	admins               : {type: [{ type: Schema.Types.ObjectId, ref: 'User' }], default: [] },
-	invited				 : [String]
+	invited				 : [String],
+	invitedUsers		 : {type: [{ type: Schema.Types.ObjectId, ref: 'User' }], default: [] },
+	invitedNonUsers		 : {type: [InvitedNonUserSchema], default: []}
 }, { usePushEach: true });
 
 OrgSchema.pre ('save', function (next) {


### PR DESCRIPTION
fix(orgs): Improvements to team member invites

Team member invites were previously tracked by recording the invited user's email address.  This caused problems if users changed their email in between when the invite was sent and when they accepted it.

This improvement tracks users by ID when that user already exists.  Emails are only used for tracking when a user is not associated with the email used for the invite.

In addition, if an invite cannot be accepted for whatever reason, a proper error message is returned to the user advising them to request a new invite from their company admin.

Fixes BA-764.