### PR TITLE
BA-898 - Fix failed loading of evaluation

### DIFF
--- a/modules/opportunities/client/directives/opportunities.eval.directive.js
+++ b/modules/opportunities/client/directives/opportunities.eval.directive.js
@@ -250,7 +250,9 @@
 								.then(totalAndSort);
 							break;
 						};
+
 						vm.isLoading = false;
+						$scope.$apply();
 					});
 				}
 

--- a/modules/opportunities/client/views/swu-opportunity-eval-directive.html
+++ b/modules/opportunities/client/views/swu-opportunity-eval-directive.html
@@ -1,6 +1,6 @@
 <div ng-if="vm.canEdit && vm.opportunity.isPublished" class="container swu-evaluation">
 
-  <div class="alert" ng-if="vm.isLoading">
+  <div class="alert" ng-show="vm.isLoading">
     <i class="fa fa-lg fa-spinner fa-spin"></i>&nbsp; Loading Evaluation...</a>
   </div>
   <div ng-show="!vm.isLoading">


### PR DESCRIPTION
fix(evaluation): Fix occasional failed loading of evaluation directive

Added a force refresh of Angular scope.  Also changed a ng-if to an ng-show for consistency.

Fixes BA-898.
