### PR TITLE
BA-898 - Fix issues around previous fix for failed eval loading

### DIFF
--- a/modules/opportunities/client/directives/opportunities.eval.directive.js
+++ b/modules/opportunities/client/directives/opportunities.eval.directive.js
@@ -25,7 +25,6 @@
 				vm.isLoading			= true;
 				vm.bestScoreWeighted 	= 5;
 
-
 				/**
 				 * Constants for evaluation stages for SWU proposals
 				 */
@@ -233,7 +232,11 @@
 									vm.opportunity.evaluationStage = vm.stages.pending_review;
 									return vm.proposals;
 								})
-								.then(totalAndSort);
+								.then(totalAndSort)
+								.then(function() {
+									vm.isLoading = false;
+									$scope.$apply();
+								});
 							break;
 
 							case vm.stages.choose_grade_type:
@@ -247,12 +250,13 @@
 								vm.responses = values.responses;
 								vm.proposals = values.proposals;
 								Promise.resolve(vm.proposals)
-								.then(totalAndSort);
+								.then(totalAndSort)
+								.then(function() {
+									vm.isLoading = false;
+									$scope.$apply();
+								});
 							break;
 						};
-
-						vm.isLoading = false;
-						$scope.$apply();
 					});
 				}
 


### PR DESCRIPTION
fix(evaluation): Additional fix for failing evaluation directive

The forced DOM update from the previous change was sometimes being applied before one of the async operations was complete.  Only occurred in the first evaluation stage, but was annoying enough that it needed an additional fix.

Fixes BA-898