### PR TITLE
BA-907 // Fix labels on opportunity list and detail pages

### DIFF
--- a/modules/opportunities/client/views/cwu-opportunity-view.html
+++ b/modules/opportunities/client/views/cwu-opportunity-view.html
@@ -157,9 +157,15 @@
 						<span ng-if="vm.opportunity.onsite == 'offsite'">In-person work NOT required</span>
 						<span ng-if="vm.opportunity.onsite == 'onsite'">In-person work required</span>
 						<span ng-if="vm.opportunity.onsite == 'mixed'">Some in-person work required</span>
-						<span class="label label-warning" ng-repeat="code in vm.opportunity.skills">{{code}}</span>
+					</dd>
+					<dt>Required skills:</dt>
+					<dd>
+						<div class="label-list">
+							<label class="label label-skill" ng-repeat="code in vm.opportunity.skills">{{code}}</label>
+						</div>
 					</dd>
 				</dl>
+				
 
 				<!--
 				<div class="label-list" style="padding-top: 4px; padding-bottom: 10px;">

--- a/modules/opportunities/client/views/opportunity-list-directive.html
+++ b/modules/opportunities/client/views/opportunity-list-directive.html
@@ -58,11 +58,14 @@
 							<button class="button-watching" ng-if="opportunity.isWatching" ng-click="vm.removeWatch(opportunity);$event.preventDefault(); $event.stopPropagation()"><i class="fa fa-eye fa-lg text-primary"></i></button>
 						</label>
 
-						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}
-							<span class="gray-light" ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
+						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}</label>
+						<label class="label label-location">
+							<span ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
+							<span ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
+							<span ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
 						</label>
+					</div>
+					<div class="label-list">
 						<label class="label label-skill" ng-repeat="code in opportunity.skills">{{code}}</label>
 					</div>
 					<div class="card-title" ng-bind="opportunity.name"></div>
@@ -72,7 +75,7 @@
 				<div class="card-body" ng-if="opportunity.opportunityTypeCd==='code-with-us'" id="opportunities.view" ui-sref="opportunities.viewcwu({ opportunityId: opportunity.code, projectId: vm.projectId })">
 					<div class="label-list">
 						<label class="label label-price">{{opportunity.earn|currency}}</label>
-						<label class="label label-swu"><i class="fa fa-users"></i> Code With Us</label>
+						<label class="label label-swu"><i class="fa fa-tag"></i> Code With Us</label>
 
 
 						<label class="label label-success" ng-if="vm.closing(opportunity) !== 'CLOSED'">OPEN</label>
@@ -85,11 +88,14 @@
 						</label>
 
 						<label class="label label-danger" ng-if="opportunity.opportunityTypeCd==='sprint-with-us'"><i class="fa fa-users"></i> Team Required </label>
-						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}
-							<span class="gray-light" ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
+						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}</label>
+						<label class="label label-location">
+							<span ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
+							<span ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
+							<span ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
 						</label>
+					</div>
+					<div class="label-list">
 						<label class="label label-skill" ng-repeat="code in opportunity.skills">{{code}}</label>
 					</div>
 					<div class="card-title" ng-bind="opportunity.name"></div>
@@ -132,11 +138,14 @@
 
 						<label class="label label-danger">CLOSED</label>
 
-						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}
-							<span class="gray-light" ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
+						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}</label>
+						<label class="label label-location">
+							<span ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
+							<span ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
+							<span ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
 						</label>
+					</div>
+					<div class="label-list">
 						<label class="label label-skill" ng-repeat="code in opportunity.skills">{{code}}</label>
 					</div>
 					<div class="card-title" ng-bind="opportunity.name"></div>
@@ -146,18 +155,21 @@
 				<div class="card-body" ng-if="opportunity.opportunityTypeCd==='code-with-us'" id="opportunities.view" ui-sref="opportunities.viewcwu({ opportunityId: opportunity.code, projectId: vm.projectId })">
 					<div class="label-list">
 						<label class="label label-price">{{opportunity.earn|currency}}</label>
-						<label class="label label-swu"><i class="fa fa-users"></i> Code With Us</label>
+						<label class="label label-swu"><i class="fa fa-tag"></i> Code With Us</label>
 
 						<label class="label label-success" ng-if="vm.closing(opportunity) !== 'CLOSED'">OPEN</label>
 
 						<label class="label label-danger" ng-if="vm.closing(opportunity) === 'CLOSED'">CLOSED</label>
 
 						<label class="label label-danger" ng-if="opportunity.opportunityTypeCd==='sprint-with-us'"><i class="fa fa-users"></i> Team Required </label>
-						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}
-							<span class="gray-light" ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
-							<span class="gray-light" ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
+						<label class="label label-location"><i class="fa fa-map-marker fa-lg"></i>&nbsp;{{opportunity.location}}</label>
+						<label class="label label-location">
+							<span ng-if="opportunity.onsite == 'offsite'">In-person work NOT required</span>
+							<span ng-if="opportunity.onsite == 'onsite'">In-person work required</span>
+							<span ng-if="opportunity.onsite == 'mixed'">Some in-person work required</span>
 						</label>
+					</div>
+					<div class="label-list">
 						<label class="label label-skill" ng-repeat="code in opportunity.skills">{{code}}</label>
 					</div>
 					<div class="card-title" ng-bind="opportunity.name"></div>

--- a/public/less/include/bc-devx.less
+++ b/public/less/include/bc-devx.less
@@ -1140,7 +1140,6 @@ form-title {
   background: transparent;
   color: @gray-dark;
   font-weight: bold;
-  font-size: .9em;
 }
 
 .label-watching {


### PR DESCRIPTION
Global styling (bc-devx.less):
- remove larger font styling for label-location

Opportunity list page:
- wrap skills in their own <div> so that skills appear on a new line on the card
- wrap on-site requirements in their own <label> to prevent the text overflowing the width of the card in mobile view
- change icon for CWU label to fa-tag, to match the descriptions of CWU/SWU at the top of the list page

CWU Opportunity detail page:
- update skills label class to label-skill to match the list page (dark orange)
- add list heading for "Required Skills: and wrap the skills labels in their own div so they display on their own line

Fixes BA-907
