### PR TITLE
BA-908 - Add check for phase selection before validating max cost

### DIFF
--- a/modules/opportunities/client/controllers/opportunities.swu.client.controller.js
+++ b/modules/opportunities/client/controllers/opportunities.swu.client.controller.js
@@ -631,7 +631,7 @@
 				return false;
 			}
 
-			if (vm.opportunity.phases.inception.maxCost > vm.opportunity.budget) {
+			if (vm.opportunity.phases.inception.isInception && vm.opportunity.phases.inception.maxCost > vm.opportunity.budget) {
 				Notification.error ({
 					message : 'You cannot enter an Inception budget greater than the total budget.',
 					title   : '<i class=\'glyphicon glyphicon-remove\'></i> Errors on Page'
@@ -639,7 +639,7 @@
 				return false;
 			}
 
-			if (vm.opportunity.phases.proto.maxCost > vm.opportunity.budget) {
+			if (vm.opportunity.phases.proto.isPrototype && vm.opportunity.phases.proto.maxCost > vm.opportunity.budget) {
 				Notification.error ({
 					message : 'You cannot enter a Proof of Concept budget greater than the total budget.',
 					title   : '<i class=\'glyphicon glyphicon-remove\'></i> Errors on Page'


### PR DESCRIPTION
feat(opportunities): Add check for phase selection before validating max cost

Added a check that was missing when validating the max costs input for each phase.  Basically, we don't want to validate phases which are not selected for that opportunity.

Fixes BA-908.
