### PR TITLE
BA-914 - Fix blank opportunity on new SWU

### DIFF
--- a/modules/opportunities/client/controllers/opportunities.swu.client.controller.js
+++ b/modules/opportunities/client/controllers/opportunities.swu.client.controller.js
@@ -254,13 +254,27 @@
 		vm.editing                       = editing;
 		vm.opportunity                   = opportunity;
 		vm.opportunity.opportunityTypeCd = 'sprint-with-us';
+
+		// Initialize phases for new opportunities
 		if (!vm.opportunity.phases) {
 			vm.opportunity.phases = {
 				implementation : {},
 				inception : {},
 				proto : {}
 			}
-		}
+		};
+
+		// Set default weights for new opportunities
+		if (!vm.opportunity.weights) {
+			vm.opportunity.weights = {
+				codechallenge	: 0.35,
+				skill           : 0.05,
+				question        : 0.25,
+				interview       : 0.25,
+				price           : 0.10
+			}
+		};
+
 		vm.oimp                   = vm.opportunity.phases.implementation;
 		vm.oinp                   = vm.opportunity.phases.inception;
 		vm.oprp                   = vm.opportunity.phases.proto;

--- a/modules/opportunities/server/models/opportunity.server.model.js
+++ b/modules/opportunities/server/models/opportunity.server.model.js
@@ -101,7 +101,7 @@ var OpportunitySchema = new Schema({
 			endDate          : {type: Date, default: Date.now },
 			startDate        : {type: Date, default: Date.now },
 			target           : {type: Number, default: 0},
-			maxCost			 : {type: Number, default: 2000000}
+			maxCost			 : {type: Number, default: 0}
 		},
 		inception : {
 			isInception      : {type: Boolean, default: false},
@@ -112,7 +112,7 @@ var OpportunitySchema = new Schema({
 			endDate          : {type: Date, default: Date.now },
 			startDate        : {type: Date, default: Date.now },
 			target           : {type: Number, default: 0},
-			maxCost			 : {type: Number, default: 100000}
+			maxCost			 : {type: Number, default: 0}
 		},
 		proto : {
 			isPrototype      : {type: Boolean, default: false},
@@ -123,7 +123,7 @@ var OpportunitySchema = new Schema({
 			endDate          : {type: Date, default: Date.now },
 			startDate        : {type: Date, default: Date.now },
 			target           : {type: Number, default: 0},
-			maxCost			 : {type: Number, default: 500000}
+			maxCost			 : {type: Number, default: 0}
 		},
 		aggregate : {
 			capabilities     : {type: [{type:Schema.ObjectId, ref: 'Capability'}], default:[]},


### PR DESCRIPTION
fix(opportunities): Fix issue where new opportunities for SWU show up with a blank view

The new feature added in BA-900 did not include initializers for the weights when creating new opportunities.  In addition, phase max costs default values should be set upon creating the opportunity instead of assuming the defaults we had in place.

- Add initializer for weights including default values
- Set phase max cost defaults to 0 on data model

Fixes BA-914.