### PR TITLE
BA-924 - Remove unnecessary pm2 module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update -q \
 #COPY phantom /opt/mean.js/node_modules
 
 # Install MEAN.JS Prerequisites
-RUN yarn global add gulp bower yo mocha karma-cli pm2 gulp-if --silent \
+RUN yarn global add gulp bower yo mocha karma-cli gulp-if --silent \
  && yarn cache clean
 
 RUN mkdir -p /opt/mean.js/public/lib


### PR DESCRIPTION
feat(build): Remove unnecessary pm2 module from Dockerfile build

The pm2 module was causing the setup.sh script to fail as it is blocked on the BCNGN network for some reason.  The module does not appear to be in use, so the easy fix is to remove it for now.

Fixes BA-924.