### PR TITLE
BA-1084 - Add code challenge draft repo link to opp view

### DIFF
--- a/modules/opportunities/client/views/swu-opportunity-view.html
+++ b/modules/opportunities/client/views/swu-opportunity-view.html
@@ -197,6 +197,13 @@
     <hr>
     <div class="row">
       <div class="col">
+        <h3 class="opp-detail">Code Challenge</h3>
+        <p>Shortlisted proponents will be required to successfully complete a code challenge.  Examples of such code challenges can be viewed <a href="https://github.com/BCDevExchange-CodeChallenge/CodeChallengeDrafts" target="_blank">here</a>.</p>
+      </div>
+    </div>
+    <hr>
+    <div class="row">
+      <div class="col">
         <h3 class="opp-detail">Proponents' Meeting</h3>
         <p>A Proponents' meeting will not be held.</p>
       </div>


### PR DESCRIPTION
feat(opportunities): Add link to opportunity view on SWU that goes to the draft code challenge repo

- The code challenge repo needs to be made public prior to merging this PR.

Fixes BA-1084.