### PR TITLE
doc: Angular Conventions should use permalink

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ Fixes #82
   * The subject line should be clear and concise as to what is being accomplished in the commit.
 * General Rules:
   * No Line in the Commit message can be longer than 80 characters.
-* Reference: [Angular Conventions](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md)
+* Reference: [Angular Conventions](https://github.com/angular/angular/blob/1b6d8a78b08f4a71631009c5ed329ecb2ef97e05/CONTRIBUTING.md#commit)


### PR DESCRIPTION
The old Angular Conventions repo has moved, and the original link was not using
a commit hash. This new link references Angular's documentation directly, and
uses a permalink.