### PR TITLE
Fix overlapping of user dropdown menu

### DIFF
--- a/modules/core/client/views/header.client.view.html
+++ b/modules/core/client/views/header.client.view.html
@@ -51,16 +51,17 @@
           </a>
         </li>
 
-        <li uib-dropdown class="nav-item">
-          <button id="single-button" type="button" class="btn btn-link profile-button caret-off" uib-dropdown-toggle>
+        <li uib-dropdown class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" id="single-button" role="button" uib-dropdown-toggle>
             <img ng-src="{{vm.avatarImageUrl}}" data-automation-id="UserAvatarImage" class="navbar-header-user-image">
-          </button>
-          <ul class="dropdown-menu" role="menu" aria-labelledby="single-button" uib-dropdown-menu>
-            <li class="dropdown-item"><a href="">{{vm.user.displayName}}</a></li>
-            <li class="dropdown-divider"></li>
-            <li class="dropdown-item" ng-repeat="item in vm.accountMenu.items"><a ui-sref="{{item.state}}" ng-bind="item.title"></a></li>
-            <li class="dropdown-item"><a href="/api/auth/signout" target="_self">Sign Out</a></li>
-          </ul>
+          </a>
+          <div class="dropdown-menu dropdown-menu-right bg-white" role="menu" aria-labelledby="single-button" uib-dropdown-menu>
+            <h6 class="dropdown-header">Signed in as {{vm.user.displayName}}</h6>
+            <div class="dropdown-divider"></div>
+            <a class="dropdown-item" ng-repeat="item in vm.accountMenu.items" ui-sref="{{item.state}}" ng-bind="item.title"></a>
+            <div class="dropdown-divider"></div>
+            <a class="dropdown-item" href="/api/auth/signout" target="_self">Sign Out</a>
+          </div>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
- changed markup to align more closely with defaults of Bootstrap 4
- added 'dropdown-menu-right' class to stop the dropdown menu from overflowing to the right side of the display
- added 'bg-white' to make it more readable over top of the black navbar

**Before:**

![user-dropdown-menu-overflows](https://user-images.githubusercontent.com/16946297/52377274-3a2baa80-2a19-11e9-887c-d1ca2ab082db.png)
![user-dropdown-menu-mobile-view](https://user-images.githubusercontent.com/16946297/52377281-3dbf3180-2a19-11e9-9e1a-908a738b9661.png)

**After:**

![after](https://user-images.githubusercontent.com/16946297/52377286-431c7c00-2a19-11e9-8d08-467ea9c918a9.png)
![after_2](https://user-images.githubusercontent.com/16946297/52377288-457ed600-2a19-11e9-8efb-0660f163a5cf.png)
