### PR TITLE
BA-1107 - Fix directives broken by uglify

### DIFF
--- a/modules/core/client/directives/forms/ModelFormatDirective.ts
+++ b/modules/core/client/directives/forms/ModelFormatDirective.ts
@@ -4,6 +4,7 @@ import angular, { IAttributes, IAugmentedJQuery, IDirective, IDirectiveFactory, 
 import { ModelFormatConfig } from '../../config/ModelFormatConfig';
 
 class ModelFormatDirective implements IDirective {
+
 	public static factory(): IDirectiveFactory {
 		return ($filter: IFilterService, $parse: IParseService) => new ModelFormatDirective($filter, $parse);
 	}
@@ -85,4 +86,4 @@ class ModelFormatDirective implements IDirective {
 	}
 }
 
-angular.module('core').directive('modelFormat', ModelFormatDirective.factory());
+angular.module('core').directive('modelFormat', ['$filter', '$parse', ModelFormatDirective.factory()]);

--- a/modules/core/client/directives/forms/PercentageFilterDirective.ts
+++ b/modules/core/client/directives/forms/PercentageFilterDirective.ts
@@ -9,7 +9,6 @@ class PercentageInputDirective implements IDirective {
 
 	public restict = 'A';
 	public require = 'ngModel';
-	public $inject = ['$filter'];
 
 	constructor(private $filter: IFilterService) {
 		this.getModelValue = this.getModelValue.bind(this);
@@ -35,4 +34,4 @@ class PercentageInputDirective implements IDirective {
 	}
 }
 
-angular.module('core').directive('percentageInput', PercentageInputDirective.factory());
+angular.module('core').directive('percentageInput', ['$filter', PercentageInputDirective.factory()]);


### PR DESCRIPTION
fix(proposals): Fix model format directive used in currency formatting.  It was being broken by the uglification/minifiation process used in prod.

Fixes BA-1107.