### PR TITLE
BA-1151: Fixes program deletion to ensure child projects and opportunities are also deleted

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
 		ApplicationConfiguration: true
 	},
 	parserOptions: {
-		sourceType: 'module'
+		sourceType: 'module',
+		ecmaVersion: 2017
 	}
 };

--- a/modules/opportunities/server/policies/OpportunitiesPolicy.ts
+++ b/modules/opportunities/server/policies/OpportunitiesPolicy.ts
@@ -89,6 +89,10 @@ class OpportunitiesPolicy {
 						permissions: ['put']
 					},
 					{
+						resources: '/api/opportunities/for/program/:programId',
+						permissions: ['get']
+					},
+					{
 						resources: '/api/opportunities/:opportunityId/action',
 						permissions: ['post']
 					},

--- a/modules/opportunities/server/routes/OpportunitiesRouter.ts
+++ b/modules/opportunities/server/routes/OpportunitiesRouter.ts
@@ -79,6 +79,9 @@ class OpportunitiesRouter {
 			.all(OpportunitiesPolicy.isAllowed)
 			.put(OpportunitiesServerController.send2FA);
 
+		// Route for retrieving all opportunities associated with a program
+		app.route('/api/opportunities/for/program/:programId').get(OpportunitiesServerController.forProgram);
+
 		// Route for actioning a pre-approval or approval request via a POST operation
 		app.route('/api/opportunities/:opportunityId/action')
 			.all(OpportunitiesPolicy.isAllowed)

--- a/modules/opportunities/server/routes/OpportunitiesRouter.ts
+++ b/modules/opportunities/server/routes/OpportunitiesRouter.ts
@@ -80,7 +80,9 @@ class OpportunitiesRouter {
 			.put(OpportunitiesServerController.send2FA);
 
 		// Route for retrieving all opportunities associated with a program
-		app.route('/api/opportunities/for/program/:programId').get(OpportunitiesServerController.forProgram);
+		app.route('/api/opportunities/for/program/:programId')
+			.all(OpportunitiesPolicy.isAllowed)
+			.get(OpportunitiesServerController.forProgram);
 
 		// Route for actioning a pre-approval or approval request via a POST operation
 		app.route('/api/opportunities/:opportunityId/action')

--- a/modules/programs/client/controllers/programs.client.controller.js
+++ b/modules/programs/client/controllers/programs.client.controller.js
@@ -81,7 +81,7 @@
 	// Controller the view of the program page
 	//
 	// =========================================================================
-	.controller('ProgramEditController', ['$scope', '$state', '$window', '$timeout', 'Upload', 'program', 'editing', 'AuthenticationService', 'Notification', 'previousState', function ($scope, $state, $window, $timeout, Upload, program, editing, authenticationService, Notification, previousState) {
+	.controller('ProgramEditController', ['$scope', '$state', '$window', '$timeout', 'Upload', 'program', 'editing', 'AuthenticationService', 'Notification', 'previousState', 'ProjectsService', 'OpportunitiesService', function ($scope, $state, $window, $timeout, Upload, program, editing, authenticationService, Notification, previousState, ProjectsService, OpportunitiesService) {
 		var vm            = this;
 		vm.user = authenticationService.user;
 		vm.fileSelected = false;
@@ -111,6 +111,27 @@
 			plugins     : 'textcolor lists advlist link',
 			toolbar     : 'undo redo | styleselect | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link | forecolor backcolor'
 		};
+		const init_deletable = async function(){
+			vm.deletable = await determineIfDeletable();
+		}
+
+		const determineIfDeletable = async function(){
+			
+			//Determine whether program has any associated open or unassigned opportunities
+			const opportunities = await fetch('/api/opportunities/for/program/'+vm.program._id).then(response => response.json());
+			const hasOpenOpportunities = opportunities.some(element => new Date().getTime() <= new Date(element.deadline).getTime());
+			const hasUnassigned = opportunities.some(element => element.status != 'Assigned');
+
+			//Determine whether program has any associated projects or opportunities
+			const projects = await fetch('/api/projects/for/program/'+vm.program._id).then(response => response.json());
+			const hasChildProjects = projects.length > 0;
+			const hasChildOpps = opportunities.length > 0;
+
+			return (!hasOpenOpportunities && !hasUnassigned && (vm.isAdmin || (program.userIs.admin && !hasChildProjects && !hasChildOpps)));
+		}
+
+		init_deletable();
+
 		vm.close = function() {
 			if (editing) {
 				$state.go('programs.view', { programId: vm.program._id });
@@ -121,11 +142,41 @@
 		}
 		// -------------------------------------------------------------------------
 		//
-		// remove the program with some confirmation
+		// remove the program and associated projects and opportunities with some confirmation
 		//
 		// -------------------------------------------------------------------------
-		vm.remove = function () {
-			if ($window.confirm('Are you sure you want to delete?')) {
+		vm.remove = async function () {
+
+			let confirmMessage = 'Are you sure you want to delete this program?\n\nThe following projects and opportunities will also be deleted:\n';
+			
+			//Fetch all projects associated with the program
+			const projects = await fetch('/api/projects/for/program/'+vm.program._id).then(response => response.json());
+			projects.forEach(function(element){
+				confirmMessage+=element.name+'\n';
+			});
+
+			//Fetch all opportunities associated with the program
+			const opportunities = await fetch('/api/opportunities/for/program/'+vm.program._id).then(response => response.json());
+			opportunities.forEach(function(element){
+				confirmMessage+=element.name+'\n';
+			});
+
+			//Show confirmation dialog
+			if ($window.confirm(confirmMessage)) {
+
+				//Delete child projects
+				projects.forEach(function(element){
+					var projectResource = new ProjectsService(element);
+					projectResource.$remove();
+				});
+
+				//Delete child opportunities
+				opportunities.forEach(function(element){
+					var opportunityResource = new OpportunitiesService(element);
+					opportunityResource.$remove();
+				});
+
+				//Delete program
 				vm.program.$remove(function() {
 					$state.go('programs.list');
 					Notification.success({ message: '<i class="fas fa-check-circle"></i> program deleted successfully!' });

--- a/modules/programs/client/views/edit-program.client.view.html
+++ b/modules/programs/client/views/edit-program.client.view.html
@@ -102,7 +102,7 @@
           <div class="col">
             <a data-automation-id="button-program-save" class="btn btn-primary float-right text-white" ng-click="vm.saveme(vm.form.programForm.$valid)"
               title="Save"><i class="fas fa-save"></i> Save &amp; Close</a>
-            <a data-automation-id="button-program-delete" ng-if="vm.editing" class="btn btn-text-only" ng-click="vm.remove()"
+            <a data-automation-id="button-program-delete" ng-if="vm.editing && vm.deletable" class="btn btn-text-only" ng-click="vm.remove()"
               title="Remove"><i class="fas fa-trash"></i> Delete this Program</a>
           </div>
         </div>


### PR DESCRIPTION
fix(programs): Fixes program deletion to ensure child projects and opportunities are also deleted

- Adds a list of child projects and opportunities that will be deleted to the program deletion confirmation dialog
- For the root admin, removes the option to delete a program if it has any child opportunities that are open or unassigned
- For the program admin, removes the option to delete a program if it has any child projects or opportunities

Fixes JIRA BA-1151