### PR TITLE
BA-1163: Fixes project deletion to ensure child opportunities are also deleted

### DIFF
--- a/modules/programs/client/controllers/programs.client.controller.js
+++ b/modules/programs/client/controllers/programs.client.controller.js
@@ -114,18 +114,22 @@
 
 		const determineIfDeletable = async function() {
 
-			// Determine whether program has any associated open or unassigned opportunities
-			const opportunities = await fetch('/api/opportunities/for/program/' + vm.program._id).then(response => response.json());
-			const hasPublished = opportunities.some(element => element.isPublished);
-			const hasAssigned = opportunities.some(element => element.status === 'Assigned');
+			if (editing){
+				// Determine whether program has any associated open or unassigned opportunities
+				const opportunities = await fetch('/api/opportunities/for/program/' + vm.program._id).then(response => response.json());
+				const hasPublished = opportunities.some(element => element.isPublished);
+				const hasAssigned = opportunities.some(element => element.status === 'Assigned');
 
-			// Determine whether program has any associated projects or opportunities
-			const projects = await fetch('/api/projects/for/program/' + vm.program._id).then(response => response.json());
-			const hasChildProjects = projects.length > 0;
-			const hasChildOpps = opportunities.length > 0;
+				// Determine whether program has any associated projects or opportunities
+				const projects = await fetch('/api/projects/for/program/' + vm.program._id).then(response => response.json());
+				const hasChildProjects = projects.length > 0;
+				const hasChildOpps = opportunities.length > 0;
 
-			// if no published opps, and no assigned opps and either root admin or program admin (with no child projects or opps)
-			return (!hasPublished && !hasAssigned && (vm.isAdmin || (program.userIs.admin && !hasChildProjects && !hasChildOpps)));
+				// if no published opps, and no assigned opps and either root admin or program admin (with no child projects or opps)
+				return (!hasPublished && !hasAssigned && (vm.isAdmin || (program.userIs.admin && !hasChildProjects && !hasChildOpps)));
+			} else {
+				return false;
+			}
 		}
 
 		const init_deletable = async function() {

--- a/modules/projects/client/views/edit-project.client.view.html
+++ b/modules/projects/client/views/edit-project.client.view.html
@@ -106,7 +106,7 @@
           <div class="col">
             <button data-automation-id="button-project-save" type="submit" class="btn btn-primary float-right" title="Save">
               <i class="fas fa-save"></i> Save &amp; Close</button>
-            <a data-automation-id="button-project-delete" ng-if="vm.editing" class="btn btn-text-only" ng-click="vm.remove()"
+            <a data-automation-id="button-project-delete" ng-if="vm.editing && vm.deletable" class="btn btn-text-only" ng-click="vm.remove()"
               title="Delete"><i class="fas fa-trash"></i> Delete this Project</a>
           </div>
         </div>


### PR DESCRIPTION
fix(projects): Fixes project deletion to ensure child opportunities are also deleted

- Adds a list of opportunities that will be deleted to the project deletion confirmation dialog
- For the root admin, removes the option to delete a project if it has any published or assigned opportunities
- For the project admin, removes the option to delete a project if it has any child opportunities
- Adds logic to remove the console error that was occurring when creating new programs or projects

Fixes BA-1163