### PR TITLE
BA-1124 - Prevent duplicate government access requests

### DIFF
--- a/modules/users/client/controllers/settings/EditProfileController.ts
+++ b/modules/users/client/controllers/settings/EditProfileController.ts
@@ -14,6 +14,7 @@ export class EditProfileController implements IController {
 	public pendingGovRequest: boolean;
 	public hasCompany: boolean;
 	public cities: string[];
+	public creatingRequest= false;
 
 	constructor(
 		private $rootScope: IRootScopeService,
@@ -51,6 +52,7 @@ export class EditProfileController implements IController {
 		const choice = await this.ask.yesNo(question);
 		if (choice) {
 			try {
+				this.creatingRequest = true;
 				this.user.addRequest = true;
 				const updatedUser = await this.UsersService.update(this.user).$promise;
 				this.pendingGovRequest = true;
@@ -60,6 +62,7 @@ export class EditProfileController implements IController {
 				});
 			} catch (error) {
 				this.handleError(error);
+				this.creatingRequest = false;
 			}
 		}
 	}

--- a/modules/users/client/views/settings/profile-main.html
+++ b/modules/users/client/views/settings/profile-main.html
@@ -51,7 +51,7 @@
       <i class="fas fa-question-circle" uib-tooltip="If you're a public sector employee in British Columbia, you can use the BCDevExchange to pay for code and hire Agile product teams."></i>
       <span class="lighter">Verify me as a BC public sector employee so I can post opportunities!</span>
 
-      <button type="button" class="btn btn-sm btn-default" ng-if="!vm.pendingGovRequest" ng-click="vm.addGovtRequest()">Send
+      <button type="button" class="btn btn-sm btn-default" ng-if="!vm.pendingGovRequest" ng-disabled="vm.creatingRequest" ng-click="vm.addGovtRequest()">Send
         Request</button>
       <button type="button" class="btn btn-sm btn-warning" ng-if="vm.pendingGovRequest" disabled>Request Pending</button>
     </label>


### PR DESCRIPTION
fix(users): Prevent duplicate government access requests by disabling the request button immediately after the user sends their first request.

Fixes BA-1124