### PR TITLE
BA-1131- Implement design changes to CWU proposal

### DIFF
--- a/modules/opportunities/client/views/cwu-opportunity-view.html
+++ b/modules/opportunities/client/views/cwu-opportunity-view.html
@@ -320,9 +320,9 @@
         <p ng-bind-html="vm.opportunity.evaluation"></p>
 
         <!-- // Proposal Application Directive // -->
-        <div class="row" ng-if="!vm.isClosed()">
+        <div class="row">
           <div class="col">
-            <proposal-apply opportunity="vm.opportunity" proposal="vm.myproposal"></proposal-apply>
+            <proposal-apply opportunity="vm.opportunity" isclosed="vm.isClosed()" proposal="vm.myproposal"></proposal-apply>
           </div>
         </div>
       </div>

--- a/modules/opportunities/client/views/cwu-opportunity-view.html
+++ b/modules/opportunities/client/views/cwu-opportunity-view.html
@@ -129,9 +129,9 @@
     </div>
 
     <!-- // Proposal Application Directive // -->
-    <div class="row" ng-if="!vm.isClosed()">
+    <div class="row">
       <div class="col">
-        <proposal-apply opportunity="vm.opportunity" proposal="vm.myproposal"></proposal-apply>
+        <proposal-apply opportunity="vm.opportunity" isclosed="vm.isClosed()" proposal="vm.myproposal"></proposal-apply>
       </div>
 
     </div>

--- a/modules/proposals/client/config/ProposalRouter.ts
+++ b/modules/proposals/client/config/ProposalRouter.ts
@@ -143,54 +143,6 @@ import { IProposalService } from '../services/ProposalService';
 					}
 				})
 
-				// create a new CWU proposal and edit it
-				.state('proposaladmin.createcwu', {
-					url: '/createcwu/:opportunityId',
-					data: {
-						roles: ['user'],
-						notroles: ['gov']
-					},
-					templateUrl: '/modules/proposals/client/views/cwu-proposal-edit.html',
-					controller: 'ProposalEditCWUController',
-					controllerAs: 'ppp',
-					resolve: {
-						proposal: [
-							'ProposalService',
-							(ProposalService: IProposalService) => {
-								return new ProposalService();
-							}
-						],
-						opportunity: [
-							'$stateParams',
-							'OpportunitiesService',
-							($stateParams: StateParams, OpportunitiesService: IOpportunitiesService) => {
-								return OpportunitiesService.get({
-									opportunityId: $stateParams.opportunityId
-								}).$promise;
-							}
-						],
-						org: [
-							'AuthenticationService',
-							'OrgService',
-							(AuthenticationService: IAuthenticationService, OrgService) => {
-								if (!AuthenticationService.user) {
-									return {};
-								}
-								return OrgService.myadmin().$promise.then(orgs => {
-									if (orgs && orgs.length > 0) {
-										return orgs[0];
-									} else {
-										return null;
-									}
-								});
-							}
-						],
-						editing() {
-							return false;
-						}
-					}
-				})
-
 				// edit a SWU proposal
 				.state('proposaladmin.editswu', {
 					url: '/:proposalId/editswu/:opportunityId',

--- a/modules/proposals/client/controllers/ProposalEditCWUController.ts
+++ b/modules/proposals/client/controllers/ProposalEditCWUController.ts
@@ -34,6 +34,7 @@ export default class ProposalEditCWUController {
 	public proposalForm: IFormController;
 
 	private user: IUser;
+	private isclosed: boolean;
 
 	constructor(
 		private $scope: IRootScopeService,
@@ -55,6 +56,12 @@ export default class ProposalEditCWUController {
 
 		// set the user
 		this.user = this.AuthenticationService.user;
+
+		this.init();
+	}
+
+	private async init(){
+		this.isclosed = await this.isClosed();
 	}
 
 	// Format dates to always be in PST (America/Vancouver timezone)
@@ -254,6 +261,13 @@ export default class ProposalEditCWUController {
 		}
 	}
 
+	// Determine whether the deadline for the opportunity has passed
+	public async isClosed(){
+		const response = await this.OpportunitiesService.getDeadlineStatus({ opportunityId: this.opportunity._id }).$promise;
+		return response.deadlineStatus === 'CLOSED'; 
+	}
+
+	// Determine whether the deadline for the opportunity has passed and send an error if it has
 	private async checkDeadline(): Promise<boolean> {
 		// Check with server to ensure deadline hasn't passed
 		const response = await this.OpportunitiesService.getDeadlineStatus({ opportunityId: this.opportunity._id }).$promise;

--- a/modules/proposals/client/controllers/ProposalEditCWUController.ts
+++ b/modules/proposals/client/controllers/ProposalEditCWUController.ts
@@ -35,6 +35,7 @@ export default class ProposalEditCWUController {
 
 	private user: IUser;
 	private isclosed: boolean;
+	private hasAttachments: boolean;
 
 	constructor(
 		private $scope: IRootScopeService,
@@ -113,16 +114,20 @@ export default class ProposalEditCWUController {
 		}
 	}
 
-	// Leave the edit view - if this was a brand new opportunity (i.e. not previously saved), delete it
+	// Leave the edit view and save any changes made if needed
 	public async close(): Promise<void> {
 
-		if (this.proposal.status === 'New') {
-			await this.proposal.$remove();
-		}
+		// If looking at a proposal for a closed opportunity, simply close the modal
+		if(this.isclosed){
+			this.$uibModalInstance.close({
+				action: ProposalModalActions.SAVED,
+				proposal: this.proposal
+			});
 
-		this.$uibModalInstance.close({
-			action: ProposalModalActions.CANCELLED
-		});
+		// If looking at a proposal for an open opportunity, save any changes made
+		}else{
+			this.save(true);
+		}
 	}
 
 	// Delete a proposal
@@ -295,6 +300,8 @@ export default class ProposalEditCWUController {
 		if (!this.proposal.team) {
 			this.proposal.team = [];
 		}
+
+		this.hasAttachments = this.proposal.attachments.length>0;
 	}
 
 	// Copy over user and org information to the proposal

--- a/modules/proposals/client/controllers/ProposalEditCWUController.ts
+++ b/modules/proposals/client/controllers/ProposalEditCWUController.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { StateService } from '@uirouter/core';
-import angular, { angularFileUpload, IFormController, IRootScopeService, uiNotification } from 'angular';
+import angular, { angularFileUpload, IFormController, IRootScopeService, ui, uiNotification } from 'angular';
 import moment from 'moment-timezone';
 import { Settings } from 'tinymce';
 import { IOpportunitiesService, IOpportunityResource } from '../../../opportunities/client/services/OpportunitiesService';
@@ -26,7 +26,8 @@ export default class ProposalEditCWUController {
 		'UsersService',
 		'Notification',
 		'org',
-		'TinyMceConfiguration'
+		'TinyMceConfiguration',
+		'$uibModalInstance'
 	];
 
 	public members: any[];
@@ -49,7 +50,8 @@ export default class ProposalEditCWUController {
 		private UsersService: IUserService,
 		private Notification: uiNotification.INotificationService,
 		public org: IOrgResource,
-		public TinyMceConfiguration: Settings
+		public TinyMceConfiguration: Settings,
+		private $uibModalInstance: ui.bootstrap.IModalServiceInstance
 	) {
 		// if not editing (i.e. creating), ensure that the current user doesn't already have a proposal started for this opp
 		// if they do, transition to edit view for that proposal
@@ -99,16 +101,14 @@ export default class ProposalEditCWUController {
 				updatedProposal = await this.ProposalService.create(this.proposal).$promise;
 			}
 
-			this.refreshProposal(updatedProposal);
 			this.Notification.success({
 				message: `<i class="fas fa-check-circle"></i> ${successMessage}`
 			});
-			this.proposalForm.$setPristine();
 
-			// if this is a newly created proposal, transition to edit view
-			if (!this.editing) {
-				this.$state.go('proposaladmin.editcwu', { proposalId: this.proposal._id, opportunityId: this.opportunity.code });
-			}
+			// close the modal and include the proposal in the response
+			this.$uibModalInstance.close({
+				proposal: updatedProposal
+			});
 		} catch (error) {
 			this.handleError(error);
 		}

--- a/modules/proposals/client/directives/ProposalApplyDirective.ts
+++ b/modules/proposals/client/directives/ProposalApplyDirective.ts
@@ -15,6 +15,7 @@ interface IProposalApplyScope extends IScope {
 	opportunity: IOpportunityResource;
 	proposal?: IProposalResource;
 	org: IOrgResource;
+	isclosed: boolean;
 }
 
 enum UserStates {
@@ -34,6 +35,7 @@ export enum ProposalModalActions {
 export class ProposalApplyDirectiveController implements IController {
 	public static $inject = ['$scope', 'AuthenticationService', 'OrgCommonService', 'modalService'];
 	public opportunity: IOpportunityResource;
+	public isclosed: boolean;
 	public proposal: IProposalResource;
 	public org: IOrgResource;
 	public user: IUser;
@@ -42,6 +44,7 @@ export class ProposalApplyDirectiveController implements IController {
 
 	constructor(private $scope: IProposalApplyScope, private AuthenticationService: IAuthenticationService, private OrgCommonService: IOrgCommonService, private modalService: any) {
 		this.opportunity = $scope.opportunity;
+		this.isclosed = $scope.isclosed;
 		this.proposal = $scope.proposal;
 		this.org = $scope.org;
 		this.userState = this.userStates.NOTHING;
@@ -156,6 +159,7 @@ angular.module('proposals').directive('proposalApply', () => {
 		templateUrl: '/modules/proposals/client/views/proposal-apply.directive.html',
 		scope: {
 			opportunity: '=',
+			isclosed: '=',
 			proposal: '=',
 			org: '='
 		},

--- a/modules/proposals/client/views/cwu-proposal-edit-attachments.html
+++ b/modules/proposals/client/views/cwu-proposal-edit-attachments.html
@@ -1,6 +1,6 @@
 <div class="m-4">
-  <div class="alert alert-info">Upload any supporting material here.</div>
-  <div>
+  <div class="alert alert-info" ng-if="!ppp.isclosed">Upload any supporting material here.</div>
+  <div ng-if="!ppp.isclosed">
     <a href class="btn btn-default" id="button-cwu-proposal-upload-file"  data-automation-id="button-cwu-proposal-upload-file" ngf-select="ppp.upload($file)"><i class="fas fa-upload"></i> Upload a
       file</a> &nbsp; <span class="text-black-50">Max 3 MB per file</span>
   </div>
@@ -14,7 +14,7 @@
           {{file.name}}
         </td>
         <td class="text-left">
-          <span ng-click="ppp.deleteAttachment(file._id)"><i class="fas fa-trash btn-remove-attachment" title="remove"></i><span>
+          <span ng-if="!ppp.isclosed" ng-click="ppp.deleteAttachment(file._id)"><i class="fas fa-trash btn-remove-attachment" title="remove"></i><span>
         </td>
       </tr>
     </table>

--- a/modules/proposals/client/views/cwu-proposal-edit-attachments.html
+++ b/modules/proposals/client/views/cwu-proposal-edit-attachments.html
@@ -11,7 +11,7 @@
           <i class="fas {{ppp.getIconName(file.type)}}"></i>
         </td>
         <td class="text-left">
-          {{file.name}}
+          <a href="/api/proposals/{{ppp.proposal._id}}/documents/{{file._id}}" target="_blank">{{file.name}}</i></a>
         </td>
         <td class="text-left">
           <span ng-if="!ppp.isclosed" ng-click="ppp.deleteAttachment(file._id)"><i class="fas fa-trash btn-remove-attachment" title="remove"></i><span>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -1,5 +1,5 @@
 <!-- // Banner if Proposal is Submitted // -->
-<div class="banner banner-success" ng-if="ppp.proposal.status === 'Submitted'">
+<div class="banner banner-success" ng-if="ppp.proposal.status === 'Submitted'&& !ppp.isclosed">
   <div class="container">
     <div class="row">
       <div class="col">
@@ -40,10 +40,10 @@
 
   <div class="modal-body">
     <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-attachments.html'"></div>
-    <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-terms.html'"></div>
+    <div ng-if="!ppp.isclosed" ng-include="'/modules/proposals/client/views/cwu-proposal-edit-terms.html'"></div>
   </div>
   
-  <div class="modal-footer justify-content-between">
+  <div class="modal-footer justify-content-between" ng-if="!ppp.isclosed">
     <!--Left-aligned button-->
     <div>
       <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" aria-label="Delete proposal" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only" data-ng-click="ppp.delete()">

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -53,13 +53,13 @@
     <!--Right-aligned buttons-->
     <div>
       <button type="button" data-automation-id="button-cwu-proposal-submit"  class="btn btn-success float-right" data-ng-click="ppp.submit()" ng-if="ppp.proposal.status === 'Draft' && ppp.proposal.isAcceptedTerms">
-        <i class="fas fa-paper-plane"></i> Submit
+        Submit
       </button>
       <button type="submit" data-automation-id="button-cwu-proposal-save-updates" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'Submitted'">
-        <i class="fas fa-save"></i> Save Updates
+        Save Updates
       </button>
       <button type="submit" data-automation-id="button-cwu-proposal-save-changes" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'New' || ppp.proposal.status === 'Draft'">
-        <i class="fas fa-save"></i> Save Changes
+        Save Changes
       </button>
     </div>
   </div>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-<section class="bg-secondary main-section">
+<section class="main-section">
 
   <form id="proposalform" name="ppp.proposalForm" class="form" ng-submit="ppp.save(ppp.proposalForm.$valid)"
     novalidate warn-on-exit>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -49,9 +49,6 @@
       <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only" data-ng-click="ppp.delete()">
         <i class=" fas fa-trash"></i> Delete My Proposal
       </button>
-      <button ng-if="ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-withdraw" class="btn btn-text-only" data-ng-click="ppp.withdraw()">
-        <i class=" fas fa-ban"></i> Withdraw Proposal
-      </button>
     </div>
     <!--Right-aligned buttons-->
     <div>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -12,7 +12,7 @@
 
 <!-- // Banner if Proposal is in Draft // -->
 <!--This can be deleted when completing BA-1160-->
-<!--
+
 <div class="banner banner-important" ng-if="ppp.proposal.status === 'Draft'">
   <div class="container">
     <div class="row">
@@ -26,9 +26,9 @@
       </div>
     </div>
   </div>
-</div>-->
+</div>
 
-<form id="proposalform" name="ppp.proposalForm" ng-submit="ppp.save(ppp.proposalForm.$valid)"
+<form id="proposalform" name="ppp.proposalForm" ng-submit="ppp.submit()"
   novalidate warn-on-exit>
 
   <div class="modal-header">
@@ -52,14 +52,8 @@
     </div>
     <!--Right-aligned buttons-->
     <div>
-      <button type="button" data-automation-id="button-cwu-proposal-submit"  class="btn btn-success float-right" data-ng-click="ppp.submit()" ng-if="ppp.proposal.status === 'Draft' && ppp.proposal.isAcceptedTerms">
+      <button type="submit" data-automation-id="button-cwu-proposal-submit"  class="btn btn-success float-right" ng-disabled="!ppp.proposal.isAcceptedTerms || !ppp.hasAttachments">
         Submit
-      </button>
-      <button type="submit" data-automation-id="button-cwu-proposal-save-updates" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'Submitted'">
-        Save Updates
-      </button>
-      <button type="submit" data-automation-id="button-cwu-proposal-save-changes" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'New' || ppp.proposal.status === 'Draft'">
-        Save Changes
       </button>
     </div>
   </div>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -11,6 +11,8 @@
 </div>
 
 <!-- // Banner if Proposal is in Draft // -->
+<!--This can be deleted when completing BA-1160-->
+<!--
 <div class="banner banner-important" ng-if="ppp.proposal.status === 'Draft'">
   <div class="container">
     <div class="row">
@@ -24,77 +26,44 @@
       </div>
     </div>
   </div>
-</div>
+</div>-->
 
-<section class="main-section">
+<form id="proposalform" name="ppp.proposalForm" ng-submit="ppp.save(ppp.proposalForm.$valid)"
+  novalidate warn-on-exit>
 
-  <form id="proposalform" name="ppp.proposalForm" class="form" ng-submit="ppp.save(ppp.proposalForm.$valid)"
-    novalidate warn-on-exit>
+  <div class="modal-header">
+    <h5 class="modal-title">Proposal</h5>
+    <button type="button" class="close" data-ng-click="ppp.close()" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
-    <div class="bg-light rounded p-0">
-
-      <div class="bg-light rounded p-3 font-weight-bold">
-        <span class="text-muted">My Proposal to Work On:</span> {{ppp.opportunity.name}}
-        <a class="btn btn-text-only float-right" data-ng-click="ppp.close()" title="Close Proposal" aria-label="Close"><i
-            class="fas fa-lg fa-times"></i></a>
-      </div>
-
-      <uib-tabset>
-
-        <uib-tab index="0">
-          <uib-tab-heading data-automation-id="tab-cwu-proposal-developer">
-            <i class="fas fa-user"></i> Developer
-          </uib-tab-heading>
-          <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-developer.html'"></div>
-        </uib-tab>
-
-        <uib-tab index="1" disable="!ppp.proposal.isCompany">
-          <uib-tab-heading data-automation-id="tab-cwu-proposal-company">
-            <i class="fas fa-building"></i> Company
-          </uib-tab-heading>
-          <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-company.html'"></div>
-        </uib-tab>
-
-        <uib-tab index="2">
-          <uib-tab-heading data-automation-id="tab-cwu-proposal-proposal">
-            <i class="fas fa-pencil-alt"></i> Proposal
-          </uib-tab-heading>
-          <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-proposal.html'"></div>
-        </uib-tab>
-
-        <uib-tab index="3" disable="!ppp.proposal._id" ng-hide="!ppp.proposal._id">
-          <uib-tab-heading data-automation-id="tab-cwu-proposal-attachment">
-            <i class="fas fa-file"></i> Attachments
-          </uib-tab-heading>
-          <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-attachments.html'"></div>
-        </uib-tab>
-
-        <uib-tab index="4" ng-if="!ppp.isSprintWithUs">
-          <uib-tab-heading data-automation-id="tab-cwu-proposal-terms">
-            <i class="far fa-handshake"></i> Terms
-          </uib-tab-heading>
-          <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-terms.html'"></div>
-        </uib-tab>
-      </uib-tabset>
-
-      <div class="bg-light rounded px-3 py-2">
-        <div class="row">
-          <div class="col">
-            <button type="button" data-automation-id="button-cwu-proposal-submit"  class="btn btn-success float-right" data-ng-click="ppp.submit()" ng-if="ppp.proposal.status === 'Draft' && ppp.proposal.isAcceptedTerms"><i
-                class="fas fa-paper-plane"></i> Submit</button>
-            <button type="submit" data-automation-id="button-cwu-proposal-save-updates" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'Submitted'"><i
-                class="fas fa-save"></i>
-              Save Updates</button>
-            <button type="submit" data-automation-id="button-cwu-proposal-save-changes" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'New' || ppp.proposal.status === 'Draft'"><i
-                class="fas fa-save"></i> Save Changes</button>
-            <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only"
-              data-ng-click="ppp.delete()" "><i class=" fas fa-trash"></i> Delete My Proposal</button>
-            <button ng-if="ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-withdraw" class="btn btn-text-only" data-ng-click="ppp.withdraw()"
-              "><i class=" fas fa-ban"></i> Withdraw Proposal</button>
-          </div>
-        </div>
-      </div>
-
+  <div class="modal-body">
+    <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-attachments.html'"></div>
+    <div ng-include="'/modules/proposals/client/views/cwu-proposal-edit-terms.html'"></div>
+  </div>
+  
+  <div class="modal-footer justify-content-between">
+    <!--Left-aligned button-->
+    <div>
+      <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only" data-ng-click="ppp.delete()">
+        <i class=" fas fa-trash"></i> Delete My Proposal
+      </button>
+      <button ng-if="ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-withdraw" class="btn btn-text-only" data-ng-click="ppp.withdraw()">
+        <i class=" fas fa-ban"></i> Withdraw Proposal
+      </button>
     </div>
-  </form>
-</section>
+    <!--Right-aligned buttons-->
+    <div>
+      <button type="button" data-automation-id="button-cwu-proposal-submit"  class="btn btn-success float-right" data-ng-click="ppp.submit()" ng-if="ppp.proposal.status === 'Draft' && ppp.proposal.isAcceptedTerms">
+        <i class="fas fa-paper-plane"></i> Submit
+      </button>
+      <button type="submit" data-automation-id="button-cwu-proposal-save-updates" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'Submitted'">
+        <i class="fas fa-save"></i> Save Updates
+      </button>
+      <button type="submit" data-automation-id="button-cwu-proposal-save-changes" class="btn btn-primary float-right" ng-if="ppp.proposal.status === 'New' || ppp.proposal.status === 'Draft'">
+        <i class="fas fa-save"></i> Save Changes
+      </button>
+    </div>
+  </div>
+</form>

--- a/modules/proposals/client/views/cwu-proposal-edit.html
+++ b/modules/proposals/client/views/cwu-proposal-edit.html
@@ -46,8 +46,8 @@
   <div class="modal-footer justify-content-between">
     <!--Left-aligned button-->
     <div>
-      <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only" data-ng-click="ppp.delete()">
-        <i class=" fas fa-trash"></i> Delete My Proposal
+      <button ng-if="ppp.proposal.status === 'Draft' || ppp.proposal.status === 'Submitted'" type="button" aria-label="Delete proposal" data-automation-id="button-cwu-proposal-delete" class="btn btn-text-only" data-ng-click="ppp.delete()">
+        <i class="far fa-trash-alt"></i>
       </button>
     </div>
     <!--Right-aligned buttons-->

--- a/modules/proposals/client/views/proposal-apply.directive.html
+++ b/modules/proposals/client/views/proposal-apply.directive.html
@@ -51,42 +51,34 @@
 
 <!-- // Code With Us // -->
 <div ng-if="$ctrl.opportunity.opportunityTypeCd !== 'sprint-with-us'">
+  
   <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_ADD">
     <div class="col px-0 pb-3">
       <button id="proposaladmin.create" ng-click="$ctrl.openProposalApplicationDialog()" class="btn btn-primary float-right">
-        <i class="fas fa-paper-plane"></i> Start a Proposal
+        Submit a proposal
       </button>
     </div>
   </div>
 
   <!-- // If user has started a Proposal // -->
   <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_EDIT">
-
-    <!-- If Proposal has been SUBMITTED -->
-    <div class="alert alert-success" ng-if="$ctrl.proposal.status === 'Submitted'">
-      <div class="col">
-        <span class="strong"><i class="fas fa-lg fa-check-circle"></i>&nbsp; Your Proposal has been submitted!</span>
-        &nbsp;You can make updates or withdraw your Proposal until <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>.
-        &nbsp;
-        <div class="update-proposal-link">
-          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">
-            <i class="fas fa-pencil-alt"></i> Update my Proposal</a>
-        </div>
-      </div>
-    </div>
-    <!-- If Proposal is in DRAFT -->
     <div class="col">
-      <div class="alert alert-warning" ng-if="$ctrl.proposal.status === 'Draft' || $ctrl.proposal.status === 'New'">
-        <span class="strong"><i class="fas fa-file"></i>&nbsp;You have a Proposal in DRAFT!</span> &nbsp;Submit before 
-        <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>
-        to be considered for this opportunity. &nbsp;
-        <div class="update-proposal-link">
-          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)"><i
-              class="fas fa-pencil-alt"></i> Update my Proposal
-          </a>
-        </div>
+      
+      <!--If proposal has been submitted. Andrew: logic change needed here I think. This needs to be visible to the user even after the closing deadline.-->
+      <div class="alert alert-success" role="alert" ng-if="$ctrl.proposal.status === 'Submitted'">
+        <i class="far fa-check-circle"></i> Your proposal has been received! 
+        <!--Andrew: please insert logic to make this span only display until the closing deadline -->
+        <span>You can submit updates until <span ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>.</span> 
+        <a class="alert-link" id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">View proposal</a>
       </div>
+      
+      <!-- If Proposal is in DRAFT -->
+      <div class="alert alert-warning" ng-if="$ctrl.proposal.status === 'Draft' || $ctrl.proposal.status === 'New'">
+        <i class="fas fa-file"></i> You have a proposal in draft. Submit before 
+        <span ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>
+        to be considered for this opportunity. <a class="alert-link" id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">View proposal</a>
+      </div>
+      
     </div>
-
   </div>
 </div>

--- a/modules/proposals/client/views/proposal-apply.directive.html
+++ b/modules/proposals/client/views/proposal-apply.directive.html
@@ -53,7 +53,7 @@
 <div ng-if="$ctrl.opportunity.opportunityTypeCd !== 'sprint-with-us'">
   <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_ADD">
     <div class="col px-0 pb-3">
-      <button id="proposaladmin.create" ng-click="$ctrl.openProposalApplicationDialog(false)" class="btn btn-primary float-right">
+      <button id="proposaladmin.create" ng-click="$ctrl.openProposalApplicationDialog()" class="btn btn-primary float-right">
         <i class="fas fa-paper-plane"></i> Start a Proposal
       </button>
     </div>
@@ -69,19 +69,19 @@
         &nbsp;You can make updates or withdraw your Proposal until <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>.
         &nbsp;
         <div class="update-proposal-link">
-          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog(true, $ctrl.proposal._id)">
+          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">
             <i class="fas fa-pencil-alt"></i> Update my Proposal</a>
         </div>
       </div>
     </div>
     <!-- If Proposal is in DRAFT -->
     <div class="col">
-      <div class="alert alert-warning" ng-if="$ctrl.proposal.status === 'Draft'">
+      <div class="alert alert-warning" ng-if="$ctrl.proposal.status === 'Draft' || $ctrl.proposal.status === 'New'">
         <span class="strong"><i class="fas fa-file"></i>&nbsp;You have a Proposal in DRAFT!</span> &nbsp;Submit before 
         <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>
         to be considered for this opportunity. &nbsp;
         <div class="update-proposal-link">
-          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog(true, $ctrl.proposal._id)"><i
+          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)"><i
               class="fas fa-pencil-alt"></i> Update my Proposal
           </a>
         </div>

--- a/modules/proposals/client/views/proposal-apply.directive.html
+++ b/modules/proposals/client/views/proposal-apply.directive.html
@@ -53,7 +53,7 @@
 <div ng-if="$ctrl.opportunity.opportunityTypeCd !== 'sprint-with-us'">
   <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_ADD">
     <div class="col px-0 pb-3">
-      <button id="proposaladmin.create" ui-sref="proposaladmin.createcwu({ opportunityId: $ctrl.opportunity._id })" class="btn btn-primary float-right">
+      <button id="proposaladmin.create" ng-click="$ctrl.openProposalApplicationDialog(false)" class="btn btn-primary float-right">
         <i class="fas fa-paper-plane"></i> Start a Proposal
       </button>
     </div>
@@ -69,8 +69,8 @@
         &nbsp;You can make updates or withdraw your Proposal until <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>.
         &nbsp;
         <div class="update-proposal-link">
-          <a id="proposaladmin.edit" ui-sref="proposaladmin.editcwu({ proposalId: $ctrl.proposal._id, opportunityId: $ctrl.opportunity._id })"><i
-              class="fas fa-pencil-alt"></i> Update my Proposal</a>
+          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog(true, $ctrl.proposal._id)">
+            <i class="fas fa-pencil-alt"></i> Update my Proposal</a>
         </div>
       </div>
     </div>
@@ -81,8 +81,9 @@
         <span class="strong" ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>
         to be considered for this opportunity. &nbsp;
         <div class="update-proposal-link">
-          <a id="proposaladmin.edit" ui-sref="proposaladmin.editcwu({ proposalId: $ctrl.proposal._id, opportunityId: $ctrl.opportunity._id })"><i
-              class="fas fa-pencil-alt"></i> Update my Proposal</a>
+          <a id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog(true, $ctrl.proposal._id)"><i
+              class="fas fa-pencil-alt"></i> Update my Proposal
+          </a>
         </div>
       </div>
     </div>

--- a/modules/proposals/client/views/proposal-apply.directive.html
+++ b/modules/proposals/client/views/proposal-apply.directive.html
@@ -52,7 +52,7 @@
 <!-- // Code With Us // -->
 <div ng-if="$ctrl.opportunity.opportunityTypeCd !== 'sprint-with-us'">
   
-  <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_ADD">
+  <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_ADD && !$ctrl.isclosed">
     <div class="col px-0 pb-3">
       <button id="proposaladmin.create" ng-click="$ctrl.openProposalApplicationDialog()" class="btn btn-primary float-right">
         Submit a proposal
@@ -64,12 +64,17 @@
   <div class="row" ng-if="$ctrl.userState === $ctrl.userStates.CAN_EDIT">
     <div class="col">
       
-      <!--If proposal has been submitted. Andrew: logic change needed here I think. This needs to be visible to the user even after the closing deadline.-->
-      <div class="alert alert-success" role="alert" ng-if="$ctrl.proposal.status === 'Submitted'">
+      <!--If proposal has been submitted and the opportunity is open. -->
+      <div class="alert alert-success" role="alert" ng-if="!$ctrl.isclosed && $ctrl.proposal.status === 'Submitted'" >
         <i class="far fa-check-circle"></i> Your proposal has been received! 
-        <!--Andrew: please insert logic to make this span only display until the closing deadline -->
         <span>You can submit updates until <span ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>.</span> 
         <a class="alert-link" id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">View proposal</a>
+      </div>
+
+      <!--If proposal has been submitted and the opportunity is closed. -->
+      <div class="alert alert-success" role="alert" ng-if="$ctrl.isclosed && ($ctrl.proposal.status === 'Submitted' || $ctrl.proposal.status === 'Assigned')">
+        <i class="far fa-check-circle"></i> The deadline for this opportunity has passed.
+        <a class="alert-link" id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">View your submitted proposal</a>
       </div>
       
       <!-- If Proposal is in DRAFT -->
@@ -78,7 +83,7 @@
         <span ng-bind="$ctrl.formatDate($ctrl.opportunity.deadline, true)"></span>
         to be considered for this opportunity. <a class="alert-link" id="proposaladmin.edit" href="" ng-click="$ctrl.openProposalApplicationDialog($ctrl.proposal._id)">View proposal</a>
       </div>
-      
+
     </div>
   </div>
 </div>

--- a/modules/proposals/server/controllers/ProposalsServerController.ts
+++ b/modules/proposals/server/controllers/ProposalsServerController.ts
@@ -90,7 +90,7 @@ class ProposalsServerController {
 	// administrator
 	public async create(req: Request, res: Response): Promise<void> {
 		const proposal = new ProposalModel(req.body);
-		proposal.status = 'Draft';
+		proposal.status = 'New';
 		proposal.user = req.user;
 
 		// set the audit fields so we know who did what when


### PR DESCRIPTION
feat(proposals): Implement design changes to CWU proposal

- If a user started or submitted a proposal for an opportunity that is now closed, add a banner with a link to allow them to view (but not edit) the proposal
- Enable users to download their uploaded attachments
- Save a proposal as a draft when the modal is closed, and remove all other 'Save' buttons from the modal

**Do not merge upon approving this PR as additional changes may be needed**

Fixes BA-1131 (BA-1158, BA-1159, BA-1160)