### PR TITLE
BA-1049 - Add timestamp for assignment of CWU opportunities

### DIFF
--- a/modules/opportunities/server/controllers/OpportunitiesServerController.ts
+++ b/modules/opportunities/server/controllers/OpportunitiesServerController.ts
@@ -224,6 +224,7 @@ class OpportunitiesServerController {
 			// update the opportunity
 			opportunity.status = 'Assigned';
 			opportunity.proposal = proposal;
+			opportunity.assignedAt = new Date();
 			const savedOpportunity = await this.updateSave(opportunity);
 
 			// update any subscribers

--- a/modules/opportunities/server/models/OpportunityModel.ts
+++ b/modules/opportunities/server/models/OpportunityModel.ts
@@ -166,6 +166,7 @@ const OpportunitySchema: Schema = new Schema(
 		issueUrl: { type: String, default: '' },
 		issueNumber: { type: String, default: '' },
 		assignment: { type: Date, default: Date.now },
+		assignedAt: { type: Date, default: null },
 		proposalEmail: { type: String, default: '' },
 		evaluation: { type: String, default: '' },
 		criteria: { type: String, default: '' },

--- a/modules/opportunities/shared/IOpportunityDTO.d.ts
+++ b/modules/opportunities/shared/IOpportunityDTO.d.ts
@@ -99,6 +99,7 @@ export interface IOpportunity {
 	issueUrl: string;
 	issueNumber: string;
 	assignment: Date;
+	assignedAt: Date;
 	proposal: IProposal;
 	phases: IPhases;
 	budget: number;


### PR DESCRIPTION
feat(opportunities): Add timestamp for assignment of CWU opportunities

- Add a timestamp in the opportunity schema to record the time at which an opportunity gets assigned to a vendor

Fixes BA-1049