### PR TITLE
BA-1133 - Fix company list view performance and security issues

### DIFF
--- a/modules/orgs/client/config/OrgClientRouter.ts
+++ b/modules/orgs/client/config/OrgClientRouter.ts
@@ -4,6 +4,7 @@ import { Ng1StateDeclaration, StateParams, StateProvider } from '@uirouter/angul
 import angular from 'angular';
 import { ICapabilitiesService } from '../../../capabilities/client/services/CapabilitiesService';
 import { IOrgService } from '../services/OrgService';
+import { OrgsListController } from '../controllers/OrgsListController';
 
 class OrgClientRouter {
 	constructor(private $stateProvider: StateProvider) {
@@ -56,7 +57,7 @@ class OrgClientRouter {
 				orgs: [
 					'OrgService',
 					(OrgService: IOrgService) => {
-						return OrgService.query().$promise;
+						return OrgService.filter({pageNumber: 1, searchTerm: '', itemsPerPage: 8}).$promise;
 					}
 				]
 			},

--- a/modules/orgs/client/config/OrgClientRouter.ts
+++ b/modules/orgs/client/config/OrgClientRouter.ts
@@ -4,7 +4,6 @@ import { Ng1StateDeclaration, StateParams, StateProvider } from '@uirouter/angul
 import angular from 'angular';
 import { ICapabilitiesService } from '../../../capabilities/client/services/CapabilitiesService';
 import { IOrgService } from '../services/OrgService';
-import { OrgsListController } from '../controllers/OrgsListController';
 
 class OrgClientRouter {
 	constructor(private $stateProvider: StateProvider) {

--- a/modules/orgs/client/controllers/OrgsListController.ts
+++ b/modules/orgs/client/controllers/OrgsListController.ts
@@ -2,7 +2,7 @@
 
 import angular, { IController } from 'angular';
 import { IAuthenticationService } from '../../../users/client/services/AuthenticationService';
-import { IOrgResource } from '../services/OrgService';
+import { IOrgResource, IOrgPagedResponse } from '../services/OrgService';
 
 // Controller for the master list of orgs
 export class OrgsListController implements IController {
@@ -10,7 +10,7 @@ export class OrgsListController implements IController {
 
 	public isLoggedIn: boolean;
 
-	constructor(public orgs: IOrgResource[], private AuthenticationService: IAuthenticationService) {
+	constructor(public orgs: IOrgPagedResponse, private AuthenticationService: IAuthenticationService) {
 		this.isLoggedIn = !!this.AuthenticationService.user;
 	}
 }

--- a/modules/orgs/client/controllers/OrgsListController.ts
+++ b/modules/orgs/client/controllers/OrgsListController.ts
@@ -2,7 +2,7 @@
 
 import angular, { IController } from 'angular';
 import { IAuthenticationService } from '../../../users/client/services/AuthenticationService';
-import { IOrgResource, IOrgPagedResponse } from '../services/OrgService';
+import { IOrgPagedResponse, IOrgResource } from '../services/OrgService';
 
 // Controller for the master list of orgs
 export class OrgsListController implements IController {

--- a/modules/orgs/client/directives/OrgListDirective.ts
+++ b/modules/orgs/client/directives/OrgListDirective.ts
@@ -6,10 +6,10 @@ import { IUserService } from '../../../users/client/services/UsersService';
 import { IUser } from '../../../users/shared/IUserDTO';
 import { IOrg } from '../../shared/IOrgDTO';
 import { IOrgCommonService } from '../services/OrgCommonService';
-import { IOrgService } from '../services/OrgService';
+import { IOrgService, IOrgPagedResponse } from '../services/OrgService';
 
 interface IOrgListDirectiveScope extends IScope {
-	orgs: IOrg[];
+	orgs: IOrgPagedResponse;
 }
 
 class OrgListDirectiveController implements IController {
@@ -19,14 +19,14 @@ class OrgListDirectiveController implements IController {
 	public isAdmin: boolean;
 	public isGov: boolean;
 	public userCanAdd: boolean;
-	public orgs: IOrg[];
+	public orgs: IOrgPagedResponse;
 
 	// Filtering and pagination related fields
 	public searchTerm = '';
 	public itemsPerPage = 8;
 	public currentPage = 1;
 	public filteredItems: IOrg[] = [];
-	public pagedItems: IOrg[] = [];
+	public totalFilteredItems: number;
 
 	constructor(
 		private $scope: IOrgListDirectiveScope,
@@ -42,7 +42,7 @@ class OrgListDirectiveController implements IController {
 		this.isAdmin = this.isUser && this.AuthenticationService.user.roles.includes('admin');
 		this.isGov = this.isUser && this.AuthenticationService.user.roles.includes('gov');
 		// set the orgs for this scope
-		this.orgs = this.$scope.orgs;
+		this.filteredItems = this.$scope.orgs.data;
 		this.init();
 	}
 
@@ -80,19 +80,27 @@ class OrgListDirectiveController implements IController {
 		return org.joinRequests.map(member => member._id).includes(userId);
 	}
 
-	public paginateItems(): void {
-		const begin = (this.currentPage - 1) * this.itemsPerPage;
-		const end = begin + this.itemsPerPage;
-		this.pagedItems = this.filteredItems.slice(begin, end);
-	}
+	public search(): void {
 
-	public filterItems(): void {
-		// reset to first page to keep it simple
+		// reset the current page to 1 for simplicity
 		this.currentPage = 1;
 
-		const searchText = this.searchTerm.toLowerCase();
-		this.filteredItems = this.orgs.filter(org => org.name.toLowerCase().includes(searchText));
-		this.paginateItems();
+		// filter orgs by the search term
+		this.filterItems();
+	}
+
+	public async filterItems(): Promise<void> {
+
+		// retrieve a filtered and paginated list of orgs
+		const response = await this.OrgService.filter({ pageNumber: this.currentPage, searchTerm: this.searchTerm, itemsPerPage: this.itemsPerPage }).$promise;
+
+		// update the list of filtered items for the current page
+		this.filteredItems = response.data;
+
+		// update the total count of filtered items (to be used for paging)
+		this.totalFilteredItems = response.totalFilteredItems;
+
+		this.$scope.$applyAsync();
 	}
 
 	public canJoinOrg(org: IOrg): boolean {
@@ -105,14 +113,14 @@ class OrgListDirectiveController implements IController {
 		if (choice) {
 			// update the list of pending requests on the org and save the org
 			try {
-				const index = this.orgs.indexOf(org);
+				const index = this.filteredItems.indexOf(org);
 				org.joinRequests.push(this.AuthenticationService.user);
 				const joinRequestResponse = await this.OrgService.joinRequest({ orgId: org._id }).$promise;
 				const updatedOrg = new this.OrgService(joinRequestResponse.org);
 				const updatedUser = new this.UsersService(joinRequestResponse.user);
 
 				// replace this org with the updated one
-				this.orgs.splice(index, 1, updatedOrg);
+				this.filteredItems.splice(index, 1, updatedOrg);
 
 				// update the user
 				this.AuthenticationService.user = updatedUser;
@@ -142,7 +150,6 @@ class OrgListDirectiveController implements IController {
 
 		// do initial filtering/paging
 		this.filterItems();
-		this.paginateItems();
 
 		this.$scope.$applyAsync();
 	}

--- a/modules/orgs/client/directives/OrgListDirective.ts
+++ b/modules/orgs/client/directives/OrgListDirective.ts
@@ -6,7 +6,7 @@ import { IUserService } from '../../../users/client/services/UsersService';
 import { IUser } from '../../../users/shared/IUserDTO';
 import { IOrg } from '../../shared/IOrgDTO';
 import { IOrgCommonService } from '../services/OrgCommonService';
-import { IOrgService, IOrgPagedResponse } from '../services/OrgService';
+import { IOrgPagedResponse, IOrgService } from '../services/OrgService';
 
 interface IOrgListDirectiveScope extends IScope {
 	orgs: IOrgPagedResponse;
@@ -133,11 +133,6 @@ class OrgListDirectiveController implements IController {
 				this.handleError(error);
 			}
 		}
-	}
-
-	public hasOrgMetRFQ(org: IOrg): boolean {
-		const status = this.OrgCommonService.hasOrgMetRFQ(org)
-		return status;
 	}
 
 	private async init(): Promise<void> {

--- a/modules/orgs/client/services/OrgService.ts
+++ b/modules/orgs/client/services/OrgService.ts
@@ -7,6 +7,9 @@ import { IOrg } from '../../shared/IOrgDTO';
 interface IOrgServiceParams {
 	orgId?: string;
 	userId?: string;
+	pageNumber?: number;
+	searchTerm?: string;
+	itemsPerPage?: number;
 }
 
 interface IOrgRequestResponse extends resource.IResource<IOrgRequestResponse> {
@@ -21,6 +24,12 @@ interface IOrgCreateResponse extends resource.IResource<IOrgCreateResponse> {
 	$promise: IPromise<IOrgCreateResponse>
 }
 
+export interface IOrgPagedResponse extends resource.IResource<IOrgPagedResponse> {
+	data: IOrg[],
+	totalFilteredItems: number,
+	$promise: IPromise<IOrgPagedResponse>
+}
+
 export interface IOrgResource extends resource.IResource<IOrgResource>, IOrg {
 	orgId: string;
 	$promise: IPromise<IOrgResource>;
@@ -30,6 +39,7 @@ export interface IOrgService extends resource.IResourceClass<IOrgResource> {
 	create(org: IOrgResource): IOrgCreateResponse;
 	update(org: IOrgResource): IOrgResource;
 	list(): IOrgResource[];
+	filter(params: IOrgServiceParams): IOrgPagedResponse;
 	my(): IOrgResource[];
 	myadmin(): IOrgResource[];
 	removeUser(params: IOrgServiceParams): IOrgResource;
@@ -55,6 +65,11 @@ angular.module('orgs.services').factory('OrgService', [
 			method: 'GET',
 			url: '/api/orgs',
 			isArray: true
+		};
+
+		const filterAction: resource.IActionDescriptor = {
+			method: 'GET',
+			url: '/api/orgs/filter'
 		};
 
 		const myAction: resource.IActionDescriptor = {
@@ -122,6 +137,7 @@ angular.module('orgs.services').factory('OrgService', [
 				create: createAction,
 				update: updateAction,
 				list: listAction,
+				filter: filterAction,
 				my: myAction,
 				myadmin: myAdminAction,
 				removeUser: removeUserAction,

--- a/modules/orgs/client/views/list.orgs.directive.html
+++ b/modules/orgs/client/views/list.orgs.directive.html
@@ -18,7 +18,7 @@
             name=""
             ng-model="vm.searchTerm"
             placeholder="Search companies..."
-            ng-change="vm.filterItems()">
+            ng-change="vm.search()">
   </div>
 </div>
 
@@ -27,7 +27,7 @@
     <div class="table-responsive">
       <table class="table table-borderless table-hover company-list">
         <tbody>
-          <tr  ng-repeat="org in vm.pagedItems" class="hover-area">
+          <tr  ng-repeat="org in vm.filteredItems" class="hover-area">
             <td class="company-logo">
               <a ng-if="org.website" href="{{org.website}}" target="_blank" title="Visit website"><img class="rounded" width="36" height="36" src="{{ org.orgImageURL }}"></a>
               <img ng-if="!org.website" class="rounded border" width="36" height="36" src="{{ org.orgImageURL }}">
@@ -64,10 +64,10 @@
   </div>
 </div>
 
-<div ng-if="vm.filteredItems.length > vm.itemsPerPage" class="row">
+<div ng-if="vm.totalFilteredItems > vm.itemsPerPage" class="row">
   <div class="col-sm-12">
-      <ul class="pagination pagination-sm justify-content-center mt-5" uib-pagination items-per-page="vm.itemsPerPage" total-items="vm.filteredItems.length" ng-model="vm.currentPage"
-      ng-change="vm.paginateItems()"></ul>
+      <ul class="pagination pagination-sm justify-content-center mt-5" uib-pagination items-per-page="vm.itemsPerPage" total-items="vm.totalFilteredItems" ng-model="vm.currentPage"
+      ng-change="vm.filterItems()"></ul>
   </div>
 </div>
 

--- a/modules/orgs/client/views/list.orgs.directive.html
+++ b/modules/orgs/client/views/list.orgs.directive.html
@@ -35,7 +35,7 @@
             </td>
             <td data-automation-id="holderCompanyName" id="holderCompanyName" class="company-name font-weight-bold text-truncate">{{ org.name }}</td>
             <td class="member-count"><i class="fas fa-users" title="{{ org.members.length }} members"></i> {{ org.members.length }}</td>
-            <td class="swu-status"><i ng-if="vm.hasOrgMetRFQ(org)" title="Sprint With Us Qualified" class="fas fa-certificate"></i></td>
+            <td class="swu-status"><i ng-if="org.hasMetRFQ" title="Sprint With Us Qualified" class="fas fa-certificate"></i></td>
             <!-- <td><i ng-if="org.awardedContractCount > 0" title="Sprint With Us Awardee" class="fas fa-trophy"></i></td> -->
             <td class="membership-status">
               <label ng-if="vm.isUserMember(org) && !vm.userIsOrgAdmin(org)" class="label label-text-only mb-0">

--- a/modules/orgs/client/views/list.orgs.directive.html
+++ b/modules/orgs/client/views/list.orgs.directive.html
@@ -17,6 +17,7 @@
             type="text"
             name=""
             ng-model="vm.searchTerm"
+            ng-model-options="{ debounce: 1000 }"
             placeholder="Search companies..."
             ng-change="vm.search()">
   </div>

--- a/modules/orgs/server/controllers/OrgsServerController.ts
+++ b/modules/orgs/server/controllers/OrgsServerController.ts
@@ -469,14 +469,14 @@ class OrgsServerController {
 	}
 
 	public async filter(req: Request, res: Response): Promise<void> {
-		const pageNumber = parseInt(req.query.pageNumber);
-		const itemsPerPage = parseInt(req.query.itemsPerPage);
+		const pageNumber = parseInt(req.query.pageNumber, 10);
+		const itemsPerPage = parseInt(req.query.itemsPerPage, 10);
 		const searchTerm = req.query.searchTerm;
-		
-		try{
+
+		try {
 			// Filter orgs by the search term
 			const filterQuery = OrgModel.find({
-				name: { $regex: searchTerm, $options: "i" }
+				name: { $regex: searchTerm, $options: 'i' }
 			})
 			// Populate orgs with only the necessary information
 			.select('name orgImageURL hasMetRFQ')
@@ -488,10 +488,10 @@ class OrgsServerController {
 			const filteredOrgs = await filterQuery.exec();
 
 			// Paginate the list of filtered orgs
-			const pagedOrgs = await filterQuery.skip(pageNumber>0? (pageNumber-1)*itemsPerPage : 0)
+			const pagedOrgs = await filterQuery.skip(pageNumber > 0 ? (pageNumber - 1) * itemsPerPage : 0)
 				.limit(itemsPerPage)
 				.exec();
-			
+
 			// Return the list of filtered orgs for the current page and the total number of filtered items
 			res.json({'data': pagedOrgs, 'totalFilteredItems': filteredOrgs.length });
 

--- a/modules/orgs/server/controllers/OrgsServerController.ts
+++ b/modules/orgs/server/controllers/OrgsServerController.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { Types } from 'mongoose';
 import multer from 'multer';
 import config from '../../../../config/ApplicationConfig';
+import { CapabilityModel} from '../../../capabilities/server/models/CapabilityModel';
 import CoreServerErrors from '../../../core/server/controllers/CoreServerErrors';
 import CoreServerHelpers from '../../../core/server/controllers/CoreServerHelpers';
 import MessagesServerController from '../../../messages/server/controllers/MessagesServerController';
@@ -36,6 +37,7 @@ class OrgsServerController {
 		this.removeMeFromCompany = this.removeMeFromCompany.bind(this);
 		this.myadmin = this.myadmin.bind(this);
 		this.my = this.my.bind(this);
+		this.checkIfRFQMet = this.checkIfRFQMet.bind(this);
 	}
 
 	public async getOrgById(id: string): Promise<IOrgModel> {
@@ -115,7 +117,11 @@ class OrgsServerController {
 				});
 			} else {
 				const populatedOrg = await this.populateOrg(updatedOrg);
-				res.json(populatedOrg);
+
+				// Check whether org now meets the RFQ requirements and update the org if necessary
+				const orgWithUpdatedRFQ = await this.checkIfRFQMet(populatedOrg);
+
+				res.json(orgWithUpdatedRFQ);
 			}
 		});
 	}
@@ -167,7 +173,7 @@ class OrgsServerController {
 				.populate('admins', this.popfields)
 				.populate('joinRequests', '_id')
 				.exec();
-				res.json(orgs);
+			res.json(orgs);
 		} catch (error) {
 			res.status(422).send({
 				message: CoreServerErrors.getErrorMessage(error)
@@ -401,9 +407,13 @@ class OrgsServerController {
 			try {
 				const updatedOrg = await org.save();
 				const updatedUser = await requestingMember.save();
+
+				// Check whether the org now meets the RFQ requirements and update the org if necessary
+				const orgWithUpdatedRFQ = await this.checkIfRFQMet(updatedOrg);
+
 				res.json({
 					user: updatedUser,
-					org: updatedOrg
+					org: orgWithUpdatedRFQ
 				});
 			} catch (error) {
 				res.status(500).send({
@@ -469,25 +479,10 @@ class OrgsServerController {
 				name: { $regex: searchTerm, $options: "i" }
 			})
 			// Populate orgs with only the necessary information
-			.select('name orgImageURL isAcceptedTerms')
+			.select('name orgImageURL hasMetRFQ')
 			.populate('admins', '_id')
-			.populate('joinRequests', '_id')
-			.populate({
-				path: 'members',
-				select: 'capabilities capabilitySkills',
-				populate: [
-					{
-						path: 'capabilities',
-						model: 'Capability',
-						select: 'code'
-					},
-					{
-						path: 'capabilitySkills',
-						model: 'CapabilitySkill',
-						select: 'code'
-					}
-				]
-			});
+			.populate('members', '_id')
+			.populate('joinRequests', '_id');
 
 			// Retrieve the list of all orgs that match the search term
 			const filteredOrgs = await filterQuery.exec();
@@ -504,6 +499,51 @@ class OrgsServerController {
 			res.status(422).send({
 				message: CoreServerErrors.getErrorMessage(error)
 			});
+		}
+	}
+
+	// Checks whether an org meets the RFQ requirements and updates the org
+	public async checkIfRFQMet(org: IOrgModel): Promise<IOrgModel> {
+		try {
+			// Check whether the org now meets the RFQ requirements
+			const metRFQ = await this.hasMetRFQ(org);
+
+			// Update and save the org
+			org.hasMetRFQ = metRFQ ? true : false;
+			org = await org.save();
+			return org;
+
+		} catch (error) {
+			throw new Error(error.message);
+		}
+	}
+
+	// Checks that the given org has met the RFQ by checking:
+	// - that the org has at least 2 team members
+	// - that the org team members collectively cover all capabilities
+	// - that the org has accepted the terms of the RFQ
+	private async hasMetRFQ(org: IOrgModel): Promise<boolean> {
+		return org.members.length >= 2 && org.isAcceptedTerms && this.isCapable(org);
+	}
+
+	// Checks whether an org's team members collectively cover all capabilities
+	private async isCapable(org: IOrgModel): Promise<boolean> {
+		try {
+			// Retrieve a list of all capabilities
+			const allCapabilities = await CapabilityModel.find({})
+			.populate('skills')
+			.exec();
+
+			// Retrieve a list of all capabilities covered by members of the org
+			const memberCaps = org.members ? _.flatten(org.members.map(member => member.capabilities)) : [];
+			const orgCapabilities = _.uniqWith(memberCaps, (cap1, cap2) => cap1.code === cap2.code);
+
+			// Determine whether the members of the org collectively cover all capabilities
+			const overlap = _.intersectionWith(allCapabilities, orgCapabilities, (cap1, cap2) => cap1.code === cap2.code);
+			return overlap.length === allCapabilities.length;
+
+		} catch (error) {
+			throw new Error(error.message);
 		}
 	}
 
@@ -584,8 +624,12 @@ class OrgsServerController {
 		// update org and return
 		org.members = org.members.filter(member => member.id !== user.id);
 		org.admins = org.admins.filter(admin => admin.id !== user.id);
-		const updatedOrg = org.save();
-		return updatedOrg;
+		const updatedOrg = await org.save();
+
+		// check whether the org now meets the RFQ requirements and update the org if necessary
+		const orgWithUpdatedRFQ = await this.checkIfRFQMet(updatedOrg);
+
+		return orgWithUpdatedRFQ;
 	}
 
 	// Populates the given org with referenced models

--- a/modules/orgs/server/controllers/OrgsServerController.ts
+++ b/modules/orgs/server/controllers/OrgsServerController.ts
@@ -469,8 +469,9 @@ class OrgsServerController {
 				name: { $regex: searchTerm, $options: "i" }
 			})
 			// Populate orgs with only the necessary information
-			.select('name orgImageURL joinRequests isAcceptedTerms')
+			.select('name orgImageURL isAcceptedTerms')
 			.populate('admins', '_id')
+			.populate('joinRequests', '_id')
 			.populate({
 				path: 'members',
 				select: 'capabilities capabilitySkills',

--- a/modules/orgs/server/models/OrgModel.ts
+++ b/modules/orgs/server/models/OrgModel.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import { Document, Model, Schema } from 'mongoose';
-import { IOrg } from '../../shared/IOrgDTO';
 import MongooseController from '../../../../config/lib/MongooseController';
+import { IOrg } from '../../shared/IOrgDTO';
 
 export interface IOrgModel extends IOrg, Document {
 	_id: string;
@@ -37,6 +37,7 @@ const OrgSchema = new Schema(
 		website: { type: String, default: '' },
 		orgImageURL: { type: String, default: 'img/default.png' },
 		isAcceptedTerms: { type: Boolean, default: false },
+		hasMetRFQ: { type: Boolean, default: false },
 		owner: { type: Schema.Types.ObjectId, ref: 'User', default: null },
 		created: { type: Date, default: null },
 		createdBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },

--- a/modules/orgs/server/policies/OrgsPolicy.ts
+++ b/modules/orgs/server/policies/OrgsPolicy.ts
@@ -24,7 +24,7 @@ class OrgsPolicy {
 					},
 					{
 						resources: '/api/orgs/filter',
-						permissions: ['*']
+						permissions: ['get']
 					},
 					{
 						resources: '/api/orgs/my',
@@ -57,7 +57,7 @@ class OrgsPolicy {
 					},
 					{
 						resources: '/api/orgs/filter',
-						permissions: ['*']
+						permissions: ['get']
 					},
 					{
 						resources: '/api/orgs/my',

--- a/modules/orgs/server/policies/OrgsPolicy.ts
+++ b/modules/orgs/server/policies/OrgsPolicy.ts
@@ -23,6 +23,10 @@ class OrgsPolicy {
 						permissions: ['*']
 					},
 					{
+						resources: '/api/orgs/filter',
+						permissions: ['*']
+					},
+					{
 						resources: '/api/orgs/my',
 						permissions: ['*']
 					},
@@ -49,6 +53,10 @@ class OrgsPolicy {
 				allows: [
 					{
 						resources: '/api/orgs',
+						permissions: ['*']
+					},
+					{
+						resources: '/api/orgs/filter',
 						permissions: ['*']
 					},
 					{
@@ -98,6 +106,10 @@ class OrgsPolicy {
 				allows: [
 					{
 						resources: '/api/orgs',
+						permissions: ['get']
+					},
+					{
+						resources: '/api/orgs/filter',
 						permissions: ['get']
 					},
 					{

--- a/modules/orgs/server/routes/OrgsRouter.ts
+++ b/modules/orgs/server/routes/OrgsRouter.ts
@@ -21,6 +21,11 @@ class OrgsRouter {
 			.get(OrgsServerController.list)
 			.post(OrgsServerController.create);
 
+		// Get a filtered and paginated list of orgs
+		app.route('/api/orgs/filter')
+			.all(OrgsPolicy.isAllowed)
+			.get(OrgsServerController.filter)
+
 		// Get a list of orgs that the user is a member of
 		app.route('/api/orgs/my')
 			.all(OrgsPolicy.isAllowed)

--- a/modules/orgs/shared/IOrgDTO.d.ts
+++ b/modules/orgs/shared/IOrgDTO.d.ts
@@ -25,6 +25,7 @@ export interface IOrg {
 	websiteAddress?: string;
 	orgImageURL: string;
 	isAcceptedTerms: boolean;
+	hasMetRFQ: boolean;
 	owner: IUser;
 	created: Date;
 	createdBy: IUser;

--- a/modules/users/server/controllers/users/UserProfileController.ts
+++ b/modules/users/server/controllers/users/UserProfileController.ts
@@ -9,6 +9,7 @@ import config from '../../../../../config/ApplicationConfig';
 import CoreServerErrors from '../../../../core/server/controllers/CoreServerErrors';
 import { SubscriptionModel } from '../../../../core/server/models/SubscriptionModel';
 import MessagesServerController from '../../../../messages/server/controllers/MessagesServerController';
+import OrgsServerController from '../../../../orgs/server/controllers/OrgsServerController';
 import { UserModel } from '../../models/UserModel';
 
 class UserProfileController {
@@ -101,6 +102,11 @@ class UserProfileController {
 						message: CoreServerErrors.getErrorMessage(err)
 					});
 				} else {
+					// Check whether the RFQ is now met for any of the orgs that the user is a member of
+					const updatedOrgs = user.orgsMember.map( async orgId => {
+						const org = await OrgsServerController.getOrgById(orgId);
+						return await OrgsServerController.checkIfRFQMet(org);
+					});
 
 					req.login(user, loginErr => {
 						if (loginErr) {


### PR DESCRIPTION
feat(orgs): Fix company list view performance and security issues by moving paging and filtering to the backend

- Perform paging and filtering on the server so that the client only gets sent information about companies on the current page
- Limit the company information that gets sent to the client
- Rather than checking whether a company has met the RFQ requirements on the client side, add a 'hasMetRFQ' field to the org model and update it on the server side when terms are accepted, when members are added or removed, and when members update their list of capabilities

Fixes BA-1133